### PR TITLE
Fix AzureRM Provider Deprecation Warning Causing Workflow Failures

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -47,8 +47,6 @@ jobs:
     if: needs.terraform.outputs.action == 'apply'
     name: Terraform Plan
     runs-on: ubuntu-latest
-    env:
-      ARM_SKIP_PROVIDER_REGISTRATION: false
     outputs:
       tfplanExitCode: ${{ steps.tf-plan.outputs.exitcode }}
 

--- a/Copilot-Processing.md
+++ b/Copilot-Processing.md
@@ -48,6 +48,87 @@ grep -r "resource_group_name.*azure_resource_group" cloudshell.tf
 - ✅ **Commit**: Comprehensive refactoring documented with detailed commit message
 
 ### 🎉 **Benefits Achieved**:
+
+---
+
+## 🔍 INFRASTRUCTURE WORKFLOW TROUBLESHOOTING - JANUARY 2025
+
+### 🎯 **Mission: Fix Failed Infrastructure Workflow**
+**Status**: 🔄 **IN PROGRESS**
+
+#### **User Request**:
+> "the latest workflow run named infrastructure failed. Examine the logs and troubleshoot the problem until you come up with a solution to refactor into the code, commit sync to github and create a PR"
+
+#### **Action Plan**:
+
+##### **Phase 1: Investigation** 🔍
+- [ ] Check current git status and branch
+- [ ] Examine recent workflow runs to identify the failed run  
+- [ ] Retrieve and analyze workflow logs
+- [ ] Identify root cause of failure
+
+##### **Phase 2: Problem Analysis** 🧪
+- [ ] Analyze error messages and failure patterns
+- [ ] Identify affected files and configuration issues
+- [ ] Determine required code changes
+
+##### **Phase 3: Solution Implementation** 🔧
+- [ ] Refactor problematic code based on findings
+- [ ] Test changes locally where possible
+- [ ] Validate configuration syntax
+
+##### **Phase 4: Git Operations** 📤
+- [ ] Stage all changes
+- [ ] Commit with descriptive message
+- [ ] Push changes to repository
+- [ ] Create pull request with detailed description
+
+#### **Investigation Log**:
+
+##### **✅ Phase 1: Investigation - COMPLETED**
+- [x] Checked current git status and branch (on main branch)
+- [x] Examined recent workflow runs to identify failed run (ID: 16686416127)
+- [x] Retrieved and analyzed workflow logs
+- [x] Identified root cause of failure
+
+##### **🔍 Root Cause Analysis**:
+**Issue Found**: AzureRM Provider Deprecation Error
+- **Problem**: Using deprecated `ARM_SKIP_PROVIDER_REGISTRATION` environment variable
+- **Error Message**: "This property is deprecated and will be removed in v5.0 of the AzureRM provider. Please use the `resource_provider_registrations` property instead."
+- **Impact**: Terraform plan failed due to deprecated configuration
+
+##### **✅ Phase 2: Problem Analysis - COMPLETED**  
+- [x] Analyzed error messages and failure patterns
+- [x] Identified affected files: `providers.tf` and `.github/workflows/infrastructure.yml`
+- [x] Determined required code changes
+
+##### **✅ Phase 3: Solution Implementation - COMPLETED**
+- [x] **Updated `providers.tf`**: Added `resource_provider_registrations = "all"` to replace deprecated setting
+- [x] **Updated `.github/workflows/infrastructure.yml`**: Removed deprecated `ARM_SKIP_PROVIDER_REGISTRATION: false` environment variable
+- [x] Validated configuration syntax with `terraform fmt` and `terraform validate`
+
+##### **📤 Phase 4: Git Operations - IN PROGRESS**
+- [ ] Stage all changes
+- [ ] Commit with descriptive message  
+- [ ] Push changes to repository
+- [ ] Create pull request with detailed description
+
+#### **Changes Made**:
+
+**File: `providers.tf`**
+```hcl
+provider "azurerm" {
+  # Use the new resource_provider_registrations instead of deprecated skip_provider_registration
+  resource_provider_registrations = "all"
+  
+  features {
+    # ... existing configuration
+  }
+}
+```
+
+**File: `.github/workflows/infrastructure.yml`**
+- Removed deprecated `ARM_SKIP_PROVIDER_REGISTRATION: false` environment variable from plan job
 - **Single Resource Group**: All infrastructure components in `azurerm_resource_group.azure_resource_group`
 - **Simplified Management**: Unified resource lifecycle and access control
 - **Consistent Tagging**: All resources follow same tagging strategy

--- a/providers.tf
+++ b/providers.tf
@@ -7,6 +7,9 @@
 ###############################################################
 
 provider "azurerm" {
+  # Use the new resource_provider_registrations instead of deprecated skip_provider_registration
+  resource_provider_registrations = "all"
+  
   features {
     api_management {
       purge_soft_delete_on_destroy = true


### PR DESCRIPTION
## 🔧 Problem Solved

This PR fixes the infrastructure workflow failure (run #16686416127) caused by deprecated AzureRM provider configuration.

## 🐛 Issue Details

**Root Cause**: Using deprecated `ARM_SKIP_PROVIDER_REGISTRATION` environment variable with AzureRM provider v4.38+

**Error Message**: 
```
This property is deprecated and will be removed in v5.0 of the AzureRM provider. 
Please use the `resource_provider_registrations` property instead.
```

**Impact**: Terraform plan step failing in GitHub Actions workflow

## ✅ Changes Made

### 1. Updated Provider Configuration (`providers.tf`)
- **Added**: `resource_provider_registrations = "all"` to azurerm provider block
- **Benefit**: Uses the modern, supported configuration method
- **Future-proofs**: Ensures compatibility with AzureRM provider v5.0+

### 2. Updated GitHub Actions Workflow (`.github/workflows/infrastructure.yml`)
- **Removed**: Deprecated `ARM_SKIP_PROVIDER_REGISTRATION: false` environment variable from plan job
- **Benefit**: Eliminates source of deprecation warnings
- **Clean**: Reduces unnecessary environment variables

## 🧪 Validation

- ✅ `terraform fmt` - No formatting issues
- ✅ `terraform validate` - Configuration is valid
- ✅ All syntax checks passed

## 📋 Migration Details

| **Before** | **After** |
|------------|-----------|
| Environment variable: `ARM_SKIP_PROVIDER_REGISTRATION: false` | Provider setting: `resource_provider_registrations = "all"` |
| Deprecated approach | Modern, supported approach |
| Causes workflow failures | Resolves workflow failures |

## 🎯 Expected Outcome

- ✅ Infrastructure workflow will run successfully
- ✅ No more deprecation warnings in terraform plan output
- ✅ Future compatibility with AzureRM provider v5.0+
- ✅ Cleaner workflow configuration

## 🔗 Related

- Fixes infrastructure workflow run #16686416127
- Addresses AzureRM provider deprecation in v4.38+
- Prepares for upcoming v5.0 provider release