### PR TITLE
Fix CloudShell VM /home LUN preservation issue and enhance documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,6 +20,9 @@
 
 ## Developer Workflow
 - **Branch Protection**: The `main` branch is protected. **All changes must be made via a pull request. Direct pushes to `main` are not allowed.**
+  - **ALWAYS create a feature branch** for any changes (e.g., `git checkout -b feature/cloudshell-fix`)
+  - **Never commit directly to main** - this will be rejected by GitHub
+  - **All deployments require PR approval** and CI/CD validation before merge
 - **GitHub CLI**: Before running any `gh` commands, disable the pager with `export GH_PAGER=` to prevent pagination issues.
 - **Pull Request Creation**: When creating a pull request, use a temporary file as the body of the pull request message instead of using a lengthy bash command.
 - **Commit**: When creating a git commit, use a temporary file as the body of the commit message instead of using a lengthy bash command.
@@ -37,7 +40,7 @@
 
 ## Project-Specific Conventions
 - **Variable Definitions**: All variables in `variables.tf` must have descriptions; sensitive variables must be marked.
-- **Adding Applications**: Create a new `spoke-k8s_application-<name>.tf` file, follow existing patterns, update variables/outputs, and push to `main`.
+- **Adding Applications**: Create a new `spoke-k8s_application-<name>.tf` file, follow existing patterns, update variables/outputs, and **create a feature branch + pull request** to deploy changes.
 - **Cloud-init**: Use YAML syntax; avoid mixing shell and cloud-init mounts. If using `mounts:`, ensure all fields are strings.
 - **CI/CD Secrets**: All secrets are injected via GitHub Actions, not stored in code.
 
@@ -49,10 +52,11 @@
 - `variables.tf` — All input variables
 
 ## Example: Adding a New Application
-1. Create `spoke-k8s_application-<name>.tf`.
-2. Define resources using existing patterns.
-3. Update `variables.tf` and outputs as needed.
-4. Commit and push to `main` to trigger deployment.
+1. **Create a feature branch**: `git checkout -b feature/add-new-app`
+2. Create `spoke-k8s_application-<name>.tf`.
+3. Define resources using existing patterns.
+4. Update `variables.tf` and outputs as needed.
+5. **Create a pull request** to merge changes into `main` and trigger deployment.
 
 ## Troubleshooting and Testing terraform
 1. run `terraform fmt` to format files

--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -24,6 +24,7 @@ bootcmd:
 
       if [[ "$always_format" == "yes" ]]; then
         echo "[INFO] Formatting $dev (forced) for $mount_point ..."
+        wipefs -a "$dev" 2>/dev/null || true  # Complete filesystem signature wipe
         parted -s "$dev" mklabel gpt mkpart primary ext4 0% 100%
         mkfs.ext4 -F "$part" -L "$label"
       else

--- a/cloudshell.tf
+++ b/cloudshell.tf
@@ -142,12 +142,12 @@ resource "random_id" "random_id" {
 }
 
 resource "azurerm_storage_account" "cloudshell_storage_account" {
-  count                    = var.cloudshell ? 1 : 0
-  name                     = "cldshl${random_id.random_id[count.index].hex}"
-  location                 = azurerm_resource_group.azure_resource_group.location
-  resource_group_name      = azurerm_resource_group.azure_resource_group.name
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
+  count                             = var.cloudshell ? 1 : 0
+  name                              = "cldshl${random_id.random_id[count.index].hex}"
+  location                          = azurerm_resource_group.azure_resource_group.location
+  resource_group_name               = azurerm_resource_group.azure_resource_group.name
+  account_tier                      = "Standard"
+  account_replication_type          = "LRS"
   infrastructure_encryption_enabled = true
   tags                              = local.standard_tags
 }
@@ -160,7 +160,13 @@ resource "azurerm_managed_disk" "cloudshell_home_disk" {
   storage_account_type = "Premium_LRS"
   create_option        = "Empty"
   disk_size_gb         = 1024
-  tags = local.standard_tags
+  tags                 = local.standard_tags
+
+  lifecycle {
+    replace_triggered_by = [
+      azurerm_linux_virtual_machine.cloudshell_vm
+    ]
+  }
 }
 
 resource "azurerm_managed_disk" "cloudshell_docker_disk" {

--- a/spoke-k8s_application-docs.tf
+++ b/spoke-k8s_application-docs.tf
@@ -44,9 +44,6 @@ resource "random_password" "salt" {
 
 resource "htpasswd_password" "hash" {
   password = var.htpasswd
-  lifecycle {
-    ignore_changes = [apr1]
-  }
 }
 
 resource "kubernetes_secret" "htpasswd_secret" {


### PR DESCRIPTION
## CloudShell VM /home LUN Preservation Issue Fix

### Problem
The CloudShell Azure virtual machine was incorrectly preserving `/home` directory contents across VM re-deployments. The `/home` LUN0 should be completely erased after each re-deploy to ensure a clean environment.

### Root Cause
While the cloud-init configuration was set to force format the `/home` disk (`format_and_mount 0 homefs /home yes`), the Azure managed disk was persisting across VM updates rather than being recreated, leading to data preservation.

### Solution Implemented

#### 1. Terraform Managed Disk Lifecycle Enhancement
- Added `replace_triggered_by` lifecycle rule to force disk recreation when VM is redeployed
- Ensures the `/home` disk is completely fresh on each deployment

#### 2. Cloud-init Formatting Improvement  
- Enhanced formatting logic with `wipefs -a "$dev"` to completely wipe existing filesystems
- Removes any remnant filesystem signatures before formatting

### Technical Changes

**Terraform (`cloudshell.tf`):**
```terraform
resource "azurerm_managed_disk" "cloudshell_home_disk" {
  # ... existing configuration ...
  lifecycle {
    replace_triggered_by = [
      azurerm_linux_virtual_machine.cloudshell_vm
    ]
  }
}
```

**Cloud-init (`cloud-init/CLOUDSHELL.conf`):**
```bash
if [[ "$always_format" == "yes" ]]; then
  echo "[INFO] Formatting $dev (forced) for $mount_point ..."
  wipefs -a "$dev" 2>/dev/null || true  # Complete wipe
  parted -s "$dev" mklabel gpt mkpart primary ext4 0% 100%
  mkfs.ext4 -F "$part" -L "$label"
```

### Additional Fixes

#### 3. Terraform Validation Warning Resolution
- **Issue**: `terraform validate` was showing a warning about redundant `ignore_changes = [apr1]` in `htpasswd_password` resource
- **Fix**: Removed the redundant `ignore_changes` block since `apr1` is provider-controlled
- **File**: `spoke-k8s_application-docs.tf`

#### 4. Enhanced Documentation
- **Updated**: `.github/copilot-instructions.md` with enhanced branch protection guidance
- **Added**: Clear instructions that main branch is protected and requires pull requests
- **Emphasized**: Feature branch workflow requirements

### Expected Results
- ✅ `/home` LUN 0 completely erased on each VM re-deployment
- ✅ No persistence of `/home` directory contents across deployments  
- ✅ Docker and Ollama disks remain preserved as intended
- ✅ Clean CloudShell environment on every deployment
- ✅ No Terraform validation warnings

### Testing
This change should be tested by:
1. Deploying the CloudShell VM with some test files in `/home`
2. Triggering a VM re-deployment via Terraform
3. Verifying that `/home` is empty and clean after re-deployment
4. Confirming Docker and Ollama volumes retain their data

### Validation
- ✅ `terraform validate` passes without warnings
- ✅ `terraform fmt` applied successfully
- ✅ All changes verified in codebase
- ✅ Documentation updated for future contributors

/cc @infrastructure-team
