### PR TITLE
fix(vscode): Fix .NET path configuration for macOS compatibility

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,17 +13,7 @@
   ],
   "github.copilot.chat.agent.thinkingTool": true,
   "chat.tools.autoApprove": true,
-  "dotnetAcquisitionExtension.existingDotnetPath": [
-    {
-      "extensionId": "MS-CST-E.vscode-devskim",
-      "path": "/usr/lib/dotnet/dotnet"
-    },
-    {
-      "extensionId": "ms-azuretools.vscode-azure-github-copilot",
-      "path": "/usr/lib/dotnet/dotnet"
-    }
-  ],
-  "dotnetAcquisitionExtension.sharedExistingDotnetPath": "/usr/lib/dotnet",
+  "dotnetAcquisitionExtension.allowInvalidPaths": true,
   "workbench.colorTheme": "Visual Studio Dark",
   "workbench.editor.enablePreview": false,
   "workbench.startupEditor": "none",


### PR DESCRIPTION
## Fix .NET Path Configuration for macOS

This PR resolves the DevSkim extension startup error on macOS by fixing the .NET path configuration.

### Problem
- VS Code settings contained Linux-specific .NET paths (`/usr/lib/dotnet/dotnet`)
- These paths don't exist on macOS, causing DevSkim extension warnings
- Error: 'existingDotnetPath' setting did not meet requirements

### Solution
- ✅ Removed hardcoded Linux .NET paths
- ✅ Added `dotnetAcquisitionExtension.allowInvalidPaths: true`
- ✅ Maintains cross-platform compatibility
- ✅ Eliminates startup warnings on macOS

### Testing
- [x] VS Code starts without .NET path warnings
- [x] DevSkim extension loads properly on macOS
- [x] Configuration remains compatible with Linux environments
- [x] Extensions can auto-install .NET if needed

This follows the extension's own suggestion and provides a clean cross-platform solution.