### PR TITLE
Remove unnecessary api_server_access_profile block from AKS cluster

### DIFF
--- a/spoke-k8s_cluster.tf
+++ b/spoke-k8s_cluster.tf
@@ -117,10 +117,6 @@ resource "azurerm_kubernetes_cluster" "kubernetes_cluster" {
     log_analytics_workspace_id      = azurerm_log_analytics_workspace.log_analytics.id
     msi_auth_for_monitoring_enabled = true
   }
-  # API Server access profile for security
-  api_server_access_profile {
-    authorized_ip_ranges = []
-  }
   # Azure Policy Add-on for governance
   azure_policy_enabled = var.production_environment ? true : false
   # Default node pool configuration


### PR DESCRIPTION
## Description

This PR removes the unnecessary `api_server_access_profile` block from the AKS cluster configuration in `spoke-k8s_cluster.tf`.

## Problem

The Terraform plan was showing unwanted drift with:
```
+ api_server_access_profile {}
```

## Analysis

- The `api_server_access_profile` block with `authorized_ip_ranges = []` provides no security benefit
- Empty IP ranges array is equivalent to no IP restrictions (public access)
- Azure API sets this property to `null` when no restrictions are configured
- This creates drift between Terraform state and Azure actual state

## Solution

Removed the empty `api_server_access_profile` block entirely since:
- No IP restrictions are needed for this cluster
- This eliminates the Terraform drift issue
- Maintains the same security posture (public access)

## Changes

- **File Modified**: `spoke-k8s_cluster.tf`
- **Lines Removed**: 121-124 (api_server_access_profile block)
- **Impact**: Prevents unnecessary Terraform plan updates

## Testing

After this change is applied:
- Terraform plan should no longer show api_server_access_profile updates
- AKS cluster will maintain public API server access (no change in functionality)
- No impact on existing cluster operations

## References

- Azure AKS API documentation confirms api_server_access_profile is optional
- Empty authorized_ip_ranges provides no additional security vs omitting the block
