### PR TITLE
Fix cloud-init POSIX compatibility issues in CLOUDSHELL.conf

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -29,7 +29,7 @@ bootcmd:
         sleep 2
       done
 
-      if [[ "$always_format" == "yes" ]]; then
+      if [ "$always_format" = "yes" ]; then
         echo "[INFO] Formatting $dev (forced) for $mount_point ..."
         wipefs -a "$dev" 2>/dev/null || true  # Complete filesystem signature wipe
         parted -s "$dev" mklabel gpt mkpart primary ext4 0% 100%
@@ -44,7 +44,7 @@ bootcmd:
         fi
       fi
 
-      mount -o defaults,nofail LABEL="$label" "$mount_point"
+      # Mount will be handled by the mounts: section
     }
 
     format_and_mount 0 homefs /home yes


### PR DESCRIPTION
## Summary
- Fix bash-specific syntax causing cloud-init bootcmd failures
- Replace `[[ ]]` with POSIX-compliant `[ ]` syntax
- Remove redundant mount command to prevent "already mounted" errors

## Test plan
- [x] Verify cloud-init syntax is POSIX-compliant
- [x] Confirm mounts: section handles filesystem mounting
- [ ] Test VM deployment with fixed cloud-init configuration
- [ ] Verify no bootcmd failures in serial console output

🤖 Generated with [Claude Code](https://claude.ai/code)