### PR TITLE
Fix permission denied errors in cloud-init install scripts

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -483,6 +483,7 @@ runcmd:
   - |
     git clone --recurse-submodules https://github.com/40docs/.github.git /root/40docs
     cd /root/40docs
+    chmod +x ./install.sh
     ./install.sh
     cd -
   - |
@@ -490,6 +491,7 @@ runcmd:
     cd /root/dotfiles
     export DOTFILES_USER=root
     export HOME=/root
+    chmod +x ./install.sh
     ./install.sh
     cd -
   - |


### PR DESCRIPTION
## Summary
- Add `chmod +x ./install.sh` before executing install scripts in cloud-init configuration
- Fixes permission denied errors when executing install.sh scripts from cloned repositories
- Ensures scripts are executable even if not cloned with execute permissions

## Test plan
- [ ] Deploy infrastructure and monitor cloud-init logs for permission errors
- [ ] Verify both 40docs/.github and dotfiles install scripts execute successfully
- [ ] Confirm no regression in existing cloud-init functionality

🤖 Generated with [Claude Code](https://claude.ai/code)