### PR TITLE
Fix critical Terraform syntax and configuration errors

### DIFF
--- a/cloud-init/fortiweb-ha.conf
+++ b/cloud-init/fortiweb-ha.conf
@@ -112,7 +112,7 @@ EOF
 config system snmp sysinfo
     set status enable
     set description "FortiWeb HA Instance - ${var_instance_role}"
-    set location "Azure Zone ${var_instance_zone:-single}"
+    set location "Azure Zone $${var_instance_zone:-single}"
     set contact-info "admin@${var_dns_zone}"
 end
 EOF
@@ -234,7 +234,7 @@ write_files:
       
       # Health check function
       check_health() {
-          local response=$(curl -s -w "%{http_code}" -o /dev/null "$HEALTH_CHECK_URL" --max-time 10)
+          local response=$(curl -s -w "%%{http_code}" -o /dev/null "$HEALTH_CHECK_URL" --max-time 10)
           
           if [ "$response" = "200" ]; then
               log_message "INFO: Health check passed (HTTP 200)"

--- a/data.tf
+++ b/data.tf
@@ -5,6 +5,9 @@
 # information about existing Azure resources and configuration.
 ###############################################################
 
+# Current Azure client configuration
+data "azurerm_client_config" "current" {}
+
 data "azurerm_public_ip" "hub_nva_management_public_ip" {
   count               = var.management_public_ip ? 1 : 0
   name                = azurerm_public_ip.hub_nva_management_public_ip[0].name

--- a/hub-nva-ha-enhanced.tf
+++ b/hub-nva-ha-enhanced.tf
@@ -193,16 +193,16 @@ resource "azurerm_linux_virtual_machine" "hub_nva_instances" {
   }
 
   source_image_reference {
-    publisher = local.vm_images.fortiweb.publisher
-    offer     = local.vm_images.fortiweb.offer
-    sku       = local.vm_images.fortiweb.sku
-    version   = local.vm_images.fortiweb.version
+    publisher = local.vm_image.fortiweb.publisher
+    offer     = local.vm_image.fortiweb.offer
+    sku       = local.vm_image.fortiweb.sku
+    version   = local.vm_image.fortiweb.version
   }
 
   plan {
-    publisher = local.vm_images.fortiweb.publisher
-    product   = local.vm_images.fortiweb.offer
-    name      = local.vm_images.fortiweb.sku
+    publisher = local.vm_image.fortiweb.publisher
+    product   = local.vm_image.fortiweb.offer
+    name      = local.vm_image.fortiweb.sku
   }
 
   custom_data = base64encode(templatefile("${path.module}/cloud-init/fortiweb-ha.conf", {
@@ -214,8 +214,7 @@ resource "azurerm_linux_virtual_machine" "hub_nva_instances" {
     var_spoke_virtual_network_address_prefix = var.spoke_virtual_network_address_prefix
     var_instance_role                        = each.key
     var_cluster_priority                     = each.value.priority
-    var_peer_ip                             = var.hub_nva_high_availability && each.key == "primary" ? 
-      local.nva_instances[1].private_ip : (var.hub_nva_high_availability ? local.nva_instances[0].private_ip : "")
+    var_peer_ip                             = var.hub_nva_high_availability && each.key == "primary" ? local.nva_instances[1].private_ip : (var.hub_nva_high_availability ? local.nva_instances[0].private_ip : "")
   }))
 
   tags = merge(local.standard_tags, {
@@ -265,9 +264,8 @@ resource "azurerm_monitor_diagnostic_setting" "hub_nva_lb_diagnostics" {
     category = "LoadBalancerProbeHealthStatus"
   }
 
-  metric {
+  enabled_metric {
     category = "AllMetrics"
-    enabled  = true
   }
 }
 

--- a/monitoring-enhanced.tf
+++ b/monitoring-enhanced.tf
@@ -199,13 +199,13 @@ resource "azurerm_monitor_metric_alert" "aks_pod_restart_alert" {
 # HTTP response time alert for applications
 resource "azurerm_monitor_metric_alert" "app_response_time_alert" {
   for_each = {
-    docs      = var.application_docs
-    dvwa      = var.application_dvwa
-    ollama    = var.application_ollama
-    extractor = var.application_extractor
+    for app, enabled in {
+      docs      = var.application_docs
+      dvwa      = var.application_dvwa
+      ollama    = var.application_ollama
+      extractor = var.application_extractor
+    } : app => app if enabled
   }
-
-  count = each.value ? 1 : 0
 
   name                = "${each.key}-response-time-alert"
   resource_group_name = azurerm_resource_group.azure_resource_group.name


### PR DESCRIPTION
## Summary
This PR resolves multiple critical Terraform syntax and configuration errors that were preventing infrastructure deployment.

## Issues Fixed
- ✅ Invalid multi-line ternary expression syntax error (hub-nva-ha-enhanced.tf:217)
- ✅ Count/for_each meta-argument conflict (monitoring-enhanced.tf:201) 
- ✅ Local variable reference inconsistency (`local.vm_images` → `local.vm_image`)
- ✅ Deprecated `metric` block updated to `enabled_metric` format
- ✅ Missing `azurerm_client_config` data source added
- ✅ Template interpolation conflicts in cloud-init configuration

## Template Fixes
- Escaped bash parameter expansion `${var_instance_zone:-single}` → `$${var_instance_zone:-single}`
- Fixed curl format string conflicts `%{http_code}` → `%%{http_code}`

## Impact
- Resolves `terraform init` failures that blocked deployment
- Eliminates syntax validation errors 
- Maintains all infrastructure functionality
- Enables successful CI/CD pipeline execution

## Testing
- ✅ `terraform init -backend=false` succeeds
- ✅ `terraform validate` passes syntax checks
- ✅ All critical blocking errors resolved

The original errors that prevented Terraform initialization are now completely resolved.

🤖 Generated with [Claude Code](https://claude.ai/code)