### PR TITLE
fix: add conditional deployment logic for single-instance vs HA NVA

### DIFF
--- a/spoke-k8s_cluster.tf
+++ b/spoke-k8s_cluster.tf
@@ -98,7 +98,8 @@ locals {
 resource "azurerm_kubernetes_cluster" "kubernetes_cluster" {
   depends_on = [
     azurerm_virtual_network_peering.spoke_to_hub_virtual_network_peering,
-    azurerm_linux_virtual_machine.hub_nva_virtual_machine
+    azurerm_linux_virtual_machine.hub_nva_virtual_machine,
+    azurerm_linux_virtual_machine.hub_nva_instances
   ]
   name                              = local.cluster_name
   location                          = azurerm_resource_group.azure_resource_group.location


### PR DESCRIPTION
## Summary
Fixed critical deployment conflict where both single-instance and high-availability (HA) NVA configurations were being created simultaneously, causing IP address allocation errors.

## Problem
The infrastructure deployment was failing with these errors:
- IP 10.0.0.5 already allocated (docs VIP conflict)
- IP 10.0.0.37 already allocated (internal interface conflict)

Both single-instance (`hub-nva.tf`) and HA (`hub-nva-ha-enhanced.tf`) resources were being deployed at the same time when `hub_nva_high_availability = true`, causing resource conflicts.

## Solution

### Added Conditional Logic to Single-Instance Resources
All single-instance resources in `hub-nva.tf` now use:
```hcl
count = \!var.hub_nva_high_availability ? 1 : 0
```

This ensures mutual exclusion:
- When `hub_nva_high_availability = true`: Only HA resources are created
- When `hub_nva_high_availability = false`: Only single-instance resources are created

### Updated Resources
- ✅ `azurerm_public_ip.hub_nva_management_public_ip`
- ✅ `azurerm_dns_cname_record.hub_nva`  
- ✅ `azurerm_availability_set.hub_nva_availability_set`
- ✅ `azurerm_network_interface.hub_nva_external_network_interface`
- ✅ `azurerm_network_interface.hub_nva_internal_network_interface`
- ✅ `azurerm_linux_virtual_machine.hub_nva_virtual_machine`

### Fixed Resource References
- Updated array indexing for resources with count
- Enhanced AKS cluster dependencies to handle both modes

## Test Results
```bash
$ terraform validate
✅ Success\! The configuration is valid.
```

## Impact
- Resolves IP allocation conflicts
- Enables proper HA deployment when `hub_nva_high_availability = true`
- Maintains backward compatibility for single-instance deployments
- Infrastructure workflow should now complete successfully

🤖 Generated with [Claude Code](https://claude.ai/code)