### PR TITLE
fix: resolve HA mode public IP reference errors

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -9,7 +9,7 @@
 data "azurerm_client_config" "current" {}
 
 data "azurerm_public_ip" "hub_nva_management_public_ip" {
-  count               = var.management_public_ip ? 1 : 0
+  count               = !var.hub_nva_high_availability && var.management_public_ip ? 1 : 0
   name                = azurerm_public_ip.hub_nva_management_public_ip[0].name
   resource_group_name = azurerm_resource_group.azure_resource_group.name
 }

--- a/hub-nva-ha-enhanced.tf
+++ b/hub-nva-ha-enhanced.tf
@@ -237,7 +237,7 @@ resource "azurerm_linux_virtual_machine" "hub_nva_instances" {
   custom_data = base64encode(templatefile("${path.module}/cloud-init/fortiweb-ha.conf", {
     var_admin_password                       = var.hub_nva_password
     var_api_user_password                    = var.hub_nva_password
-    var_fqdn_management                      = var.management_public_ip ? azurerm_public_ip.hub_nva_management_public_ip[0].fqdn : ""
+    var_fqdn_management                      = var.management_public_ip ? azurerm_public_ip.hub_nva_ha_management_public_ips[each.key].fqdn : ""
     var_dns_zone                             = var.dns_zone
     var_privatekey                           = tls_private_key.private_key.private_key_pem
     var_spoke_virtual_network_address_prefix = var.spoke_virtual_network_address_prefix

--- a/outputs.tf
+++ b/outputs.tf
@@ -58,10 +58,18 @@ output "dns_zone_name_servers" {
 # NVA Management Access
 output "hub_nva_management_public_ip" {
   description = "Public IP address for NVA management (if enabled)"
-  value       = var.management_public_ip ? azurerm_public_ip.hub_nva_management_public_ip[0].ip_address : null
+  value = var.management_public_ip ? (
+    var.hub_nva_high_availability ? {
+      for k, v in azurerm_public_ip.hub_nva_ha_management_public_ips : k => v.ip_address
+    } : azurerm_public_ip.hub_nva_management_public_ip[0].ip_address
+  ) : null
 }
 
 output "hub_nva_management_fqdn" {
   description = "FQDN for NVA management access (if enabled)"
-  value       = var.management_public_ip ? azurerm_public_ip.hub_nva_management_public_ip[0].fqdn : null
+  value = var.management_public_ip ? (
+    var.hub_nva_high_availability ? {
+      for k, v in azurerm_public_ip.hub_nva_ha_management_public_ips : k => v.fqdn
+    } : azurerm_public_ip.hub_nva_management_public_ip[0].fqdn
+  ) : null
 }


### PR DESCRIPTION
## Summary
Fixed Terraform plan errors that occurred when `hub_nva_high_availability = true` due to invalid references to single-instance public IP resources that are not created in HA mode.

## Problem  
When HA mode is enabled, single-instance resources have `count = 0`, but several files were still trying to reference them:

### Errors Fixed:
```
Error: Invalid index
  on data.tf line 13: azurerm_public_ip.hub_nva_management_public_ip is empty tuple

Error: Invalid index  
  on hub-nva-ha-enhanced.tf line 240: azurerm_public_ip.hub_nva_management_public_ip is empty tuple

Error: Invalid index
  on outputs.tf line 61: azurerm_public_ip.hub_nva_management_public_ip is empty tuple
```

## Solution

### 1. Fixed Data Source (data.tf)
- Added HA condition to management public IP data source
- Only fetches when `\!var.hub_nva_high_availability && var.management_public_ip`

### 2. Fixed HA VM Template (hub-nva-ha-enhanced.tf)  
- Changed from single-instance management IP reference to HA-specific IPs
- Uses `azurerm_public_ip.hub_nva_ha_management_public_ips[each.key].fqdn`

### 3. Enhanced Outputs (outputs.tf)
- Updated outputs to handle both deployment modes
- Returns map of IPs for HA mode, single IP for single-instance mode

## Test Results
```bash
$ terraform validate
✅ Success\! The configuration is valid.
```

## Impact
- Resolves terraform plan failures when HA mode is enabled
- Maintains backward compatibility for single-instance deployments
- Provides proper outputs for both deployment modes

🤖 Generated with [Claude Code](https://claude.ai/code)