### PR TITLE
fix: force recreation of HA resources to resolve NIC attachment conflicts

### DIFF
--- a/hub-nva-ha-enhanced.tf
+++ b/hub-nva-ha-enhanced.tf
@@ -227,6 +227,13 @@ resource "random_string" "vm_suffix" {
   upper   = false
   special = false
   numeric = true
+  
+  # Add a keeper to force regeneration when we need to replace all HA resources
+  # This ensures clean slate when old resources have conflicts
+  keepers = {
+    # Update this timestamp to force all HA resources to be recreated
+    deployment_id = "20250809-171000"
+  }
 }
 
 # FortiWeb Virtual Machines


### PR DESCRIPTION
## Summary
- Fix NIC deletion conflicts where old VMs are still attached to NICs being deleted
- Force recreation of all HA resources with completely new names by updating random_string keepers
- Resolves terraform apply failure with NicInUse errors

## Root Cause
The deployment was failing because:
- Old VMs (hub-nva-primary, hub-nva-secondary) were still using NICs
- Terraform was trying to delete these NICs to recreate them with random suffixes
- Azure blocks NIC deletion when NICs are attached to existing VMs

## Solution
- Add keepers to `random_string.vm_suffix` with deployment timestamp
- This forces the random string to regenerate, triggering recreation of all HA resources
- New resources get completely unique names, avoiding conflicts with orphaned resources

## Test Plan
- [x] Terraform format and validate passes locally
- [x] Changes target only HA resource naming conflicts
- [ ] Verify infrastructure deployment completes without NIC errors
- [ ] Confirm new VMs are created with unique suffixes and old ones removed

🤖 Generated with [Claude Code](https://claude.ai/code)