### PR TITLE
fix: add aggressive lifecycle rules to force complete HA resource recreation

### DIFF
--- a/hub-nva-ha-enhanced.tf
+++ b/hub-nva-ha-enhanced.tf
@@ -158,6 +158,14 @@ resource "azurerm_network_interface" "hub_nva_external_interfaces" {
     azurerm_linux_virtual_machine.hub_nva_virtual_machine
   ]
 
+  # Force recreation when random suffix changes
+  lifecycle {
+    create_before_destroy = false
+    replace_triggered_by = [
+      random_string.vm_suffix.keepers
+    ]
+  }
+
   name                           = "hub-nva-${each.key}-external-nic-${random_string.vm_suffix.result}"
   location                       = azurerm_resource_group.azure_resource_group.location
   resource_group_name            = azurerm_resource_group.azure_resource_group.name
@@ -184,6 +192,14 @@ resource "azurerm_network_interface" "hub_nva_internal_interfaces" {
     azurerm_network_interface.hub_nva_internal_network_interface,
     azurerm_linux_virtual_machine.hub_nva_virtual_machine
   ]
+
+  # Force recreation when random suffix changes
+  lifecycle {
+    create_before_destroy = false
+    replace_triggered_by = [
+      random_string.vm_suffix.keepers
+    ]
+  }
 
   name                = "hub-nva-${each.key}-internal-nic-${random_string.vm_suffix.result}"
   location            = azurerm_resource_group.azure_resource_group.location
@@ -232,7 +248,8 @@ resource "random_string" "vm_suffix" {
   # This ensures clean slate when old resources have conflicts
   keepers = {
     # Update this timestamp to force all HA resources to be recreated
-    deployment_id = "20250809-171000"
+    # Updated to force complete recreation and resolve persistent NIC conflicts
+    deployment_id = "20250809-171400"
   }
 }
 
@@ -246,6 +263,14 @@ resource "azurerm_linux_virtual_machine" "hub_nva_instances" {
   size                            = var.production_environment ? "Standard_F4s_v2" : "Standard_F2s_v2"
   zone                            = each.value.zone
   disable_password_authentication = false #tfsec:ignore:AVD-AZU-0039
+
+  # Force recreation when random suffix changes
+  lifecycle {
+    create_before_destroy = false
+    replace_triggered_by = [
+      random_string.vm_suffix.keepers
+    ]
+  }
 
   # Enhanced identity for monitoring and management
   identity {


### PR DESCRIPTION
## Summary
- Add explicit lifecycle rules to VMs and NICs to force recreation when random suffix changes
- Update deployment timestamp to trigger fresh random suffix generation  
- Use create_before_destroy = false to ensure proper resource destruction order

## Root Cause Analysis
The NIC conflicts persist because Terraform state still contains old HA resources (hub-nva-primary-external-nic, etc.) that are attached to VMs with the same names. The keepers approach alone wasn't sufficient to force recreation of all dependent resources.

## Solution
This change implements a more aggressive recreation strategy:

1. **Updated Deployment ID**: Changed timestamp from `20250809-171000` to `20250809-171400` to force new random suffix
2. **Explicit Lifecycle Rules**: Added `replace_triggered_by = [random_string.vm_suffix.keepers]` to all HA resources
3. **Destruction Order**: Set `create_before_destroy = false` to ensure old resources are destroyed before creating new ones

## Expected Behavior
- All HA resources (VMs, NICs, LB, etc.) will be destroyed with old names
- New resources created with unique random suffixes (e.g., hub-nva-primary-abc123)
- No NIC attachment conflicts since old VMs are destroyed first

## Test Plan
- [x] Terraform format and validate passes locally
- [x] Added lifecycle rules to force recreation of all HA components
- [ ] Verify deployment completes without NicInUse errors
- [ ] Confirm new infrastructure uses unique resource names

🤖 Generated with [Claude Code](https://claude.ai/code)