### PR TITLE
fix: temporarily disable HA mode to clear conflicting resources from state

### DIFF
--- a/variables-ha-enhanced.tf
+++ b/variables-ha-enhanced.tf
@@ -8,7 +8,8 @@
 variable "hub_nva_high_availability" {
   type        = bool
   description = "Enable high availability deployment with multiple FortiWeb instances across availability zones"
-  default     = true
+  # Temporarily disabled to clear conflicting HA resources from state
+  default     = false
 }
 
 variable "hub_nva_admin_username" {


### PR DESCRIPTION
## Summary
- Temporarily set `hub_nva_high_availability = false` to clear conflicting HA resources from Terraform state
- This allows single-instance NVA deployment to proceed and destroy orphaned HA resources
- Next step will be to re-enable HA mode once state is clean

## Root Cause
The persistent NIC conflicts occur because Terraform state contains references to old HA resources:
- `hub-nva-primary` and `hub-nva-secondary` VMs
- Associated NICs without random suffixes that can't be deleted while attached

## Two-Phase Solution
**Phase 1 (This PR)**: Disable HA mode
- Single-instance deployment will destroy conflicting HA resources
- Clean Terraform state of problematic resource references
- Allow successful deployment without NIC conflicts

**Phase 2 (Next PR)**: Re-enable HA mode  
- Fresh HA deployment with clean state
- All resources will use proper random suffixes
- No conflicts with orphaned resources

## Expected Behavior
- HA resources (load balancer, multiple VMs, etc.) will be destroyed
- Single FortiWeb instance will be deployed successfully
- Terraform state will be clean for fresh HA deployment

## Test Plan
- [x] Single-instance deployment should complete without NIC errors
- [ ] Verify all conflicting HA resources are removed from Azure
- [ ] Confirm Terraform state no longer contains orphaned resource references
- [ ] Ready for Phase 2: re-enabling HA mode

🤖 Generated with [Claude Code](https://claude.ai/code)