### PR TITLE
fix: resolve configuration errors when switching between HA and single-instance modes

### DIFF
--- a/monitoring-enhanced.tf
+++ b/monitoring-enhanced.tf
@@ -83,7 +83,7 @@ resource "azurerm_monitor_metric_alert" "fortiweb_cpu_alert" {
 
   name                = "fortiweb-${each.key}-cpu-alert"
   resource_group_name = azurerm_resource_group.azure_resource_group.name
-  scopes              = [azurerm_linux_virtual_machine.hub_nva_instances[each.key].id]
+  scopes              = [var.hub_nva_high_availability ? azurerm_linux_virtual_machine.hub_nva_instances[each.key].id : azurerm_linux_virtual_machine.hub_nva_virtual_machine[0].id]
   description         = "Alert when FortiWeb ${each.key} CPU utilization exceeds threshold"
   severity            = 2
   frequency           = "PT1M"
@@ -111,7 +111,7 @@ resource "azurerm_monitor_metric_alert" "fortiweb_memory_alert" {
 
   name                = "fortiweb-${each.key}-memory-alert"
   resource_group_name = azurerm_resource_group.azure_resource_group.name
-  scopes              = [azurerm_linux_virtual_machine.hub_nva_instances[each.key].id]
+  scopes              = [var.hub_nva_high_availability ? azurerm_linux_virtual_machine.hub_nva_instances[each.key].id : azurerm_linux_virtual_machine.hub_nva_virtual_machine[0].id]
   description         = "Alert when FortiWeb ${each.key} available memory is low"
   severity            = 2
   frequency           = "PT1M"

--- a/outputs.tf
+++ b/outputs.tf
@@ -61,7 +61,9 @@ output "hub_nva_management_public_ip" {
   value = var.management_public_ip ? (
     var.hub_nva_high_availability ? {
       for k, v in azurerm_public_ip.hub_nva_ha_management_public_ips : k => v.ip_address
-    } : azurerm_public_ip.hub_nva_management_public_ip[0].ip_address
+    } : {
+      single = azurerm_public_ip.hub_nva_management_public_ip[0].ip_address
+    }
   ) : null
 }
 
@@ -70,6 +72,8 @@ output "hub_nva_management_fqdn" {
   value = var.management_public_ip ? (
     var.hub_nva_high_availability ? {
       for k, v in azurerm_public_ip.hub_nva_ha_management_public_ips : k => v.fqdn
-    } : azurerm_public_ip.hub_nva_management_public_ip[0].fqdn
+    } : {
+      single = azurerm_public_ip.hub_nva_management_public_ip[0].fqdn
+    }
   ) : null
 }


### PR DESCRIPTION
## Summary
- Fix Invalid index errors in monitoring-enhanced.tf when HA mode is disabled
- Fix type inconsistency errors in outputs.tf between HA and single-instance modes
- Allow terraform plan to succeed when hub_nva_high_availability = false

## Root Cause
When HA mode is disabled (`hub_nva_high_availability = false`), Terraform plan failed with:

1. **Invalid index errors**: 
   - `monitoring-enhanced.tf` tried to reference `azurerm_linux_virtual_machine.hub_nva_instances[each.key].id`
   - But `hub_nva_instances` resource doesn't exist in single-instance mode

2. **Type inconsistency errors**:
   - `outputs.tf` conditional expressions returned different types
   - HA mode: object (map), Single mode: string
   - Terraform requires consistent types in conditional expressions

## Solution
**Monitoring References**: Added conditional VM resource references
```hcl
# Before (HA only)
scopes = [azurerm_linux_virtual_machine.hub_nva_instances[each.key].id]

# After (both modes)  
scopes = [var.hub_nva_high_availability 
  ? azurerm_linux_virtual_machine.hub_nva_instances[each.key].id 
  : azurerm_linux_virtual_machine.hub_nva_virtual_machine[0].id]
```

**Output Types**: Made both modes return consistent object types
```hcl
# Before (inconsistent types)
var.hub_nva_high_availability ? { ... } : "string_value"

# After (consistent object types)
var.hub_nva_high_availability ? { ... } : { single = "string_value" }
```

## Expected Behavior
- Terraform plan will succeed in both HA and single-instance modes
- Single-instance deployment can proceed to clear conflicting HA resources
- Ready for Phase 2: re-enabling HA mode with clean state

## Test Plan  
- [x] Configuration validated for both HA modes
- [ ] Single-instance deployment completes successfully
- [ ] Conflicting HA resources are removed from Azure and Terraform state
- [ ] Ready for HA re-enablement in next iteration

🤖 Generated with [Claude Code](https://claude.ai/code)