### PR TITLE
fix: enhance state cleanup to remove all Kubernetes and Flux resources

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -84,14 +84,15 @@ jobs:
           ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
         run: |
           echo "Removing orphaned Kubernetes resources from state..."
-          # Remove Kubernetes namespace resources that no longer exist
-          terraform state list | grep 'kubernetes_namespace\.' | while read resource; do
+          
+          # Remove all Kubernetes resources that depend on the deleted cluster
+          terraform state list | grep -E '^kubernetes_' | while read resource; do
             echo "Attempting to remove $resource from state..."
             terraform state rm "$resource" || echo "Resource $resource not found in state"
           done
           
           # Remove Flux resources that depend on non-existent cluster
-          terraform state list | grep 'flux_bootstrap_git\.' | while read resource; do
+          terraform state list | grep -E '^flux_' | while read resource; do
             echo "Attempting to remove $resource from state..."
             terraform state rm "$resource" || echo "Resource $resource not found in state"
           done


### PR DESCRIPTION
## Problem
The previous fix only removed namespace resources, but Kubernetes secrets and other resources were still causing connection timeouts.

## Solution  
- Enhanced cleanup to remove ALL `kubernetes_*` resources from state
- Enhanced cleanup to remove ALL `flux_*` resources from state  
- This ensures complete state cleanup when the cluster is manually deleted

## Testing
This should resolve the remaining connection timeout errors for Kubernetes secrets and other resources.

## Expected Result
The workflow should now be able to run successfully without any Kubernetes connection errors.