### PR TITLE
fix: handle large terraform plan output in GitHub Actions

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -162,26 +162,29 @@ jobs:
 
       - name: Create String Output
         id: tf-plan-string
+        continue-on-error: true
         run: |
-          TERRAFORM_PLAN=$(terraform show -no-color tfplan)
+          TERRAFORM_PLAN=$(terraform show -no-color tfplan | head -200)  # Limit to first 200 lines
           delimiter="$(openssl rand -hex 8)"
           {
             echo "summary<<${delimiter}"
-            echo "## Terraform Plan Output"
+            echo "## Terraform Plan Output (First 200 lines)"
             echo "<details><summary>Click to expand</summary>"
             echo ""
             echo '```terraform'
             echo "$TERRAFORM_PLAN"
             echo '```'
             echo "</details>"
+            echo "Full plan available in tfplan artifact"
             echo "${delimiter}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Publish Terraform Plan to Task Summary
+        continue-on-error: true
         env:
           SUMMARY: ${{ steps.tf-plan-string.outputs.summary }}
         run: |
-          echo "$SUMMARY" >> "$GITHUB_STEP_SUMMARY"
+          echo "$SUMMARY" >> "$GITHUB_STEP_SUMMARY" || echo "Plan too large for summary, check artifacts"
 
   apply:
     name: Terraform Apply


### PR DESCRIPTION
## Problem
The terraform plan step succeeded, but the workflow failed when trying to publish a large plan output to the GitHub Actions summary. This prevented the Apply step from running.

## Solution
- Limit terraform plan summary to first 200 lines to avoid 'Argument list too long' error
- Add `continue-on-error: true` to prevent workflow failure when plan output is large  
- Reference full plan in tfplan artifact for complete details
- This allows the workflow to proceed to apply step even with large plans

## Testing
The terraform plan itself worked successfully (Plan: 100 to add, 0 to change, 5 to destroy), only the summary publishing failed.

## Expected Result
The workflow should now complete successfully and proceed to the Apply step.