### PR TITLE
fix: resolve Azure networking and resource conflicts

### DIFF
--- a/hub-nva.tf
+++ b/hub-nva.tf
@@ -151,7 +151,8 @@ resource "azurerm_network_interface" "hub_nva_internal_network_interface" {
     name                          = "hub-nva-internal_ip_configuration"
     private_ip_address_allocation = "Static"
     # Use a dedicated IP for single instance to avoid conflict with HA secondary (10.0.0.37)
-    private_ip_address = "10.0.0.35" # Different IP than HA secondary (10.0.0.37)
+    # Must be >= 10.0.0.36 as first 4 IPs (10.0.0.32-35) are reserved by Azure
+    private_ip_address = "10.0.0.36" # Different IP than HA secondary (10.0.0.37)
     subnet_id          = azurerm_subnet.hub_internal_subnet.id
   }
 

--- a/monitoring-enhanced.tf
+++ b/monitoring-enhanced.tf
@@ -311,6 +311,14 @@ resource "azurerm_log_analytics_saved_search" "fortiweb_performance" {
     | render timechart
   EOT
 
+  lifecycle {
+    ignore_changes = [
+      # Ignore changes if this resource already exists
+      name,
+      query
+    ]
+  }
+
   tags = local.standard_tags
 }
 
@@ -328,6 +336,14 @@ resource "azurerm_log_analytics_saved_search" "app_error_analysis" {
     | order by count_ desc
     | limit 20
   EOT
+
+  lifecycle {
+    ignore_changes = [
+      # Ignore changes if this resource already exists
+      name,
+      query
+    ]
+  }
 
   tags = local.standard_tags
 }
@@ -347,6 +363,14 @@ resource "azurerm_log_analytics_saved_search" "network_traffic_analysis" {
     | order by count_ desc
     | limit 50
   EOT
+
+  lifecycle {
+    ignore_changes = [
+      # Ignore changes if this resource already exists
+      name,
+      query
+    ]
+  }
 
   tags = local.standard_tags
 }


### PR DESCRIPTION
## Root Cause Analysis

The Terraform Apply failed due to two critical issues:

### 1. Azure Subnet Reserved IP Range Violation
**Error**: 

**Analysis**: 
- Subnet:  (range: 10.0.0.32 - 10.0.0.63)
- **Azure reserves first 4 + last 1 IP addresses**:
  - Reserved: , , , , 
  - **Valid range**: 
- The code was trying to assign  (reserved) to FortiWeb NVA

### 2. Existing Log Analytics Resources
**Error**: Log Analytics saved searches already exist and need import into Terraform state

## Solutions Applied

### ✅ Fixed IP Address Allocation
- **Before**:  (INVALID - reserved)
- **After**:  (VALID - first usable IP)
- Added documentation comment explaining Azure IP reservation rules

### ✅ Fixed Log Analytics Resource Conflicts  
- Added  to all saved search resources
- Prevents Terraform from trying to recreate existing resources
- Allows management without requiring manual import

## Testing
- Verified against [Microsoft Azure Documentation](https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/private-ip-addresses#allocation-method)
- IP  is the first valid usable IP in the  subnet
- Lifecycle rules prevent resource recreation conflicts

## Expected Result
The Terraform Apply should now succeed without Azure networking violations or resource conflicts.