### PR TITLE
Fix workflow condition for RESET_STATE variable

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -76,6 +76,7 @@ jobs:
         run: terraform init
 
       - name: Clean orphaned state resources
+        if: vars.RESET_STATE == 'true'
         continue-on-error: true
         env:
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
@@ -83,7 +84,7 @@ jobs:
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
           ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
         run: |
-          echo "Removing orphaned Kubernetes resources from state..."
+          echo "RESET_STATE is enabled - removing orphaned Kubernetes resources from state..."
           
           # Remove all Kubernetes resources that depend on the deleted cluster
           terraform state list | grep -E '^kubernetes_' | while read resource; do


### PR DESCRIPTION
## Summary

This fixes the root cause of the deployment failures where Kubernetes namespaces were being removed from Terraform state on every deployment, causing 'already exists' errors.

## Problem
The 'Clean orphaned state resources' step in the GitHub Actions workflow was running unconditionally on every deployment, regardless of the RESET_STATE variable value. Even with RESET_STATE=false, the step would execute and remove all Kubernetes resources from Terraform state, causing conflicts when physical resources remained in the cluster.

## Solution
- Added missing condition 'if: vars.RESET_STATE == 'true'' to the Clean orphaned state resources step
- Updated echo message to indicate when RESET_STATE is enabled
- This ensures the state cleaning only runs when explicitly requested

## Testing Plan
- [x] Verified RESET_STATE is currently set to false
- [x] Confirmed namespaces exist in AKS cluster (docs, dvwa, cert-manager, ingress-helper, lacework-agent)
- [x] Identified that workflow was running state cleanup unconditionally
- [ ] Test deployment after merge to validate namespace conflicts are resolved

## Evidence
Previous workflow runs failed with errors like:
- 'namespaces "docs" already exists'
- 'namespaces "dvwa" already exists'
- 'namespaces "cert-manager" already exists'

These occurred because the workflow removed resources from state but left physical resources in the cluster.

## Impact
This change prevents state drift issues and allows successful deployments when RESET_STATE=false, while preserving the ability to clean orphaned state when RESET_STATE=true is explicitly set.