### PR TITLE
Fix: Export BRAVE_API_KEY and PERPLEXITY_API_KEY in CloudShell environment

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -568,6 +568,10 @@ runcmd:
     ollama pull gpt-oss:20b
     echo 'export OLLAMA_API_BASE=http://127.0.0.1:11434' >> /root/.zshrc
     echo 'export OLLAMA_API_BASE=http://127.0.0.1:11434' >> /root/.bashrc
+    echo 'export BRAVE_API_KEY="${var_brave_api_key}"' >> /root/.bashrc
+    echo 'export BRAVE_API_KEY="${var_brave_api_key}"' >> /root/.zshrc
+    echo 'export PERPLEXITY_API_KEY="${var_perplexity_api_key}"' >> /root/.bashrc
+    echo 'export PERPLEXITY_API_KEY="${var_perplexity_api_key}"' >> /root/.zshrc
   - curl -s https://fluxcd.io/install.sh | bash -s --
   #- curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
   #- install -o root -g root -m 0755 kubectl /usr/bin/kubectl


### PR DESCRIPTION
## Summary
Fixes the missing API key exports in the CloudShell VM environment.

## Problem
PR #167 added the API key variables and passed them to the cloud-init template, but they weren't actually exported as environment variables in the VM, making them unavailable to applications.

## Solution
- Added `export BRAVE_API_KEY` and `export PERPLEXITY_API_KEY` statements to cloud-init template
- API keys are now properly exported to both `.bashrc` and `.zshrc` during VM provisioning
- Environment variables will be available in all shell sessions (bash/zsh)

## Flow
```
GitHub Secrets → Terraform Variables → Cloud-init Template → Shell Environment Variables
```

## Changes
- **cloud-init/CLOUDSHELL.conf**: Added 4 export statements for API keys in both bash and zsh

## Testing
- [x] `terraform fmt` passes
- [x] `terraform validate` passes
- [x] Template syntax verified

## Impact
After this fix, CloudShell VM will have:
- `$BRAVE_API_KEY` available for Brave Search integration
- `$PERPLEXITY_API_KEY` available for Perplexity AI integration