### PR TITLE
Enhance CloudShell MCP configuration with jq-based API key injection

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -780,6 +780,22 @@ runcmd:
     cp -a /root/.bashrc /etc/skel
     cp -a /root/.cache /etc/skel
     cp -a /root/.config /etc/skel
+    # Update Claude MCP configuration with API keys
+    if [ -f /root/.claude/mcp.json ]; then
+      # Add Brave Search server and update API keys in mcp.json
+      jq --arg brave_key "${var_brave_api_key}" --arg perplexity_key "${var_perplexity_api_key}" '
+        .servers["brave-search"] = {
+          "type": "stdio",
+          "command": "npx",
+          "args": ["@modelcontextprotocol/server-brave-search"],
+          "env": {
+            "BRAVE_API_KEY": $brave_key
+          }
+        } |
+        .servers.Perplexity.env.PERPLEXITY_API_KEY = $perplexity_key |
+        del(.inputs)
+      ' /root/.claude/mcp.json > /root/.claude/mcp.json.tmp && mv /root/.claude/mcp.json.tmp /root/.claude/mcp.json
+    fi
     cp -a /root/.claude /etc/skel
     cp -a /root/.digrc /etc/skel
     cp -a /root/.dotnet /etc/skel


### PR DESCRIPTION
## Summary
This PR improves the CloudShell cloud-init configuration to use jq for dynamically updating the ~/.claude/mcp.json file with API keys, rather than relying on environment variables and input prompts.

## Changes Made
- **Added jq-based MCP configuration update**: Dynamically modifies ~/.claude/mcp.json to inject API keys
- **Added Brave Search server configuration**: Includes the @modelcontextprotocol/server-brave-search server
- **Replaced input variables**: Removes the need for user input prompts by directly setting API key values  
- **Removed inputs section**: Eliminates the manual input requirement for API keys
- **Positioned correctly**: Executes just before copying to /etc/skel to ensure all users get the updated configuration

## Technical Details
The jq command:
1. Adds a new 'brave-search' server configuration with the BRAVE_API_KEY
2. Updates the existing Perplexity server to use the actual PERPLEXITY_API_KEY value
3. Removes the inputs section since API keys are now hardcoded
4. Executes safely with file existence check and atomic replacement

## Benefits
- **Seamless integration**: No manual API key entry required for CloudShell users
- **Better UX**: Claude Code will have immediate access to Brave Search and Perplexity
- **Consistent configuration**: All users get the same pre-configured MCP setup
- **Secure**: API keys are injected at VM creation time from Terraform variables

## Testing
- [x] Terraform validate passes
- [x] jq syntax verified
- [x] Proper positioning before /etc/skel copy operation
- [x] Maintains existing functionality while adding improvements

This enhancement builds on PR #168 by providing a more sophisticated approach to API key management in the CloudShell environment.