### PR TITLE
Fix: Update .claude/mcp.json with actual API keys instead of input placeholders

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -780,6 +780,15 @@ runcmd:
     cp -a /root/.bashrc /etc/skel
     cp -a /root/.cache /etc/skel
     cp -a /root/.config /etc/skel
+    # Update Claude MCP configuration with API keys
+    if [ -f /root/.claude/mcp.json ]; then
+      # Update API keys in mcp.json and replace input placeholders with actual values
+      jq --arg brave_key "${var_brave_api_key}" --arg perplexity_key "${var_perplexity_api_key}" '
+        .mcpServers.Perplexity.env.PERPLEXITY_API_KEY = $perplexity_key |
+        .mcpServers["brave-search"].env.BRAVE_API_KEY = $brave_key |
+        del(.inputs)
+      ' /root/.claude/mcp.json > /root/.claude/mcp.json.tmp && mv /root/.claude/mcp.json.tmp /root/.claude/mcp.json
+    fi
     cp -a /root/.claude /etc/skel
     cp -a /root/.digrc /etc/skel
     cp -a /root/.dotnet /etc/skel


### PR DESCRIPTION
## Summary
Fixes the Claude Code MCP configuration to use actual API key values instead of input placeholders.

## Problem
The  file currently uses:
- `"PERPLEXITY_API_KEY": "${input:perplexity-api-key}"`
- `"BRAVE_API_KEY": "${input:brave_api_key}"`

These placeholders require manual user input each time, making the MCP servers non-functional without manual configuration.

## Solution
Added a jq-based transformation during CloudShell VM provisioning that:
- Replaces `${input:perplexity-api-key}` with the actual PERPLEXITY_API_KEY value
- Replaces `${input:brave_api_key}` with the actual BRAVE_API_KEY value  
- Removes the `.inputs` section containing placeholder definitions

## Technical Details
```bash
jq --arg brave_key "${var_brave_api_key}" --arg perplexity_key "${var_perplexity_api_key}" '
  .mcpServers.Perplexity.env.PERPLEXITY_API_KEY = $perplexity_key |
  .mcpServers["brave-search"].env.BRAVE_API_KEY = $brave_key |
  del(.inputs)
' /root/.claude/mcp.json > /root/.claude/mcp.json.tmp && mv /root/.claude/mcp.json.tmp /root/.claude/mcp.json
```

## Flow
```
GitHub Secrets → Terraform Variables → Cloud-init Template → jq Transformation → Working MCP Configuration
```

## Changes
- **cloud-init/CLOUDSHELL.conf**: Added jq transformation to update MCP configuration

## Testing  
- [x] `terraform fmt` passes
- [x] `terraform validate` passes
- [x] jq command tested with sample JSON structure

## Impact
After this fix:
- ✅ CloudShell users will have working Brave Search and Perplexity MCP servers immediately
- ✅ No manual API key input required
- ✅ MCP servers auto-configured with actual API keys during VM provisioning