### PR TITLE
Fix: Correct template variable names for API keys in cloud-init

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -783,7 +783,7 @@ runcmd:
     # Update Claude MCP configuration with API keys
     if [ -f /root/.claude/mcp.json ]; then
       # Update API keys in mcp.json and replace input placeholders with actual values
-      jq --arg brave_key "${var_brave_api_key}" --arg perplexity_key "${var_perplexity_api_key}" '
+      jq --arg brave_key "${brave_api_key}" --arg perplexity_key "${perplexity_api_key}" '
         .mcpServers.Perplexity.env.PERPLEXITY_API_KEY = $perplexity_key |
         .mcpServers["brave-search"].env.BRAVE_API_KEY = $brave_key |
         del(.inputs)


### PR DESCRIPTION
## Summary
Fixes the template variable references in cloud-init/CLOUDSHELL.conf to use the correct Terraform variable names.

## Problem
The jq transformation for updating .claude/mcp.json was using incorrect template variable names:
- Used: `${var_brave_api_key}` (incorrect)
- Should be: `${brave_api_key}` (correct)
- Used: `${var_perplexity_api_key}` (incorrect) 
- Should be: `${perplexity_api_key}` (correct)

## Solution
- Fixed template variables to match the actual Terraform variable names defined in variables.tf
- Ensures the jq transformation will receive actual API key values during VM provisioning
- Completes the API key integration for CloudShell MCP servers

## Testing
- [x] Template variable names match those defined in variables.tf
- [x] Cloud-init syntax validation
- [x] Ready for deployment validation

This is a critical fix that ensures the CloudShell VM will have working MCP servers with actual API keys instead of placeholder values.