### PR TITLE
Fix: Correct template variable mapping for API keys in cloudshell.tf

### DIFF
--- a/cloudshell.tf
+++ b/cloudshell.tf
@@ -234,8 +234,8 @@ resource "azurerm_linux_virtual_machine" "cloudshell_vm" {
         var_forticnapp_api_secret    = var.forticnapp_api_secret
         var_kubeconfig               = local.kubeconfig
         var_admin_username           = var.cloudshell_admin_username
-        var_brave_api_key            = var.brave_api_key
-        var_perplexity_api_key       = var.perplexity_api_key
+        brave_api_key                = var.brave_api_key
+        perplexity_api_key           = var.perplexity_api_key
       }
     )
   )


### PR DESCRIPTION
## Summary
Fixes the Terraform template variable mapping in cloudshell.tf to match what the cloud-init template expects.

## Problem
The terraform plan was failing with error:
```
Invalid value for "vars" parameter: vars map does not contain key "brave_api_key", referenced at ./cloud-init/CLOUDSHELL.conf:786,29-42.
```

This happened because:
- cloudshell.tf was passing: `var_brave_api_key` and `var_perplexity_api_key`
- cloud-init template expected: `brave_api_key` and `perplexity_api_key`

## Solution
Updated the template variable mapping in cloudshell.tf:
- `var_brave_api_key` → `brave_api_key`
- `var_perplexity_api_key` → `perplexity_api_key`

## Testing
- [x] Template variable names now match cloud-init expectations
- [x] Ready for terraform plan validation

This completes the API key integration for CloudShell MCP servers.