### PR TITLE
Fix: Update remaining API key template variable references in cloud-init

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -568,10 +568,10 @@ runcmd:
     ollama pull gpt-oss:20b
     echo 'export OLLAMA_API_BASE=http://127.0.0.1:11434' >> /root/.zshrc
     echo 'export OLLAMA_API_BASE=http://127.0.0.1:11434' >> /root/.bashrc
-    echo 'export BRAVE_API_KEY="${var_brave_api_key}"' >> /root/.bashrc
-    echo 'export BRAVE_API_KEY="${var_brave_api_key}"' >> /root/.zshrc
-    echo 'export PERPLEXITY_API_KEY="${var_perplexity_api_key}"' >> /root/.bashrc
-    echo 'export PERPLEXITY_API_KEY="${var_perplexity_api_key}"' >> /root/.zshrc
+    echo 'export BRAVE_API_KEY="${brave_api_key}"' >> /root/.bashrc
+    echo 'export BRAVE_API_KEY="${brave_api_key}"' >> /root/.zshrc
+    echo 'export PERPLEXITY_API_KEY="${perplexity_api_key}"' >> /root/.bashrc
+    echo 'export PERPLEXITY_API_KEY="${perplexity_api_key}"' >> /root/.zshrc
   - curl -s https://fluxcd.io/install.sh | bash -s --
   #- curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
   #- install -o root -g root -m 0755 kubectl /usr/bin/kubectl


### PR DESCRIPTION
## Summary
Fixes the remaining template variable references in cloud-init/CLOUDSHELL.conf export statements.

## Problem
Even after fixing the jq transformation and terraform variable mapping, the terraform plan was still failing with:
```
Invalid value for "vars" parameter: vars map does not contain key "var_brave_api_key", referenced at ./cloud-init/CLOUDSHELL.conf:571,35-52.
```

This was because the export statements in the cloud-init script still used the old variable names:
- Lines 571-574 used `${var_brave_api_key}` and `${var_perplexity_api_key}`

## Solution
Updated all remaining template variable references:
- `${var_brave_api_key}` → `${brave_api_key}` (in export statements)
- `${var_perplexity_api_key}` → `${perplexity_api_key}` (in export statements)

## Verification
- [x] No remaining references to old variable names: `grep -n "var_brave_api_key\|var_perplexity_api_key" cloud-init/CLOUDSHELL.conf` returns no matches
- [x] All template variables now use consistent naming throughout the file
- [x] Ready for final terraform plan validation

This should complete the API key integration for CloudShell MCP servers.