### PR TITLE
Fix: Improve jq command safety in MCP configuration

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -782,8 +782,8 @@ runcmd:
     cp -a /root/.config /etc/skel
     # Update Claude MCP configuration with API keys
     if [ -f /root/.claude/mcp.json ]; then
-      jq --in-place '.mcpServers.Perplexity.env.PERPLEXITY_API_KEY = "${var_perplexity_api_key}"' /root/.claude/mcp.json
-      jq --in-place '.mcpServers["brave-search"].env.BRAVE_API_KEY = "${var_brave_api_key}"' /root/.claude/mcp.json
+      jq '.mcpServers.Perplexity.env.PERPLEXITY_API_KEY = "${var_perplexity_api_key}"' /root/.claude/mcp.json > /tmp/mcp.json && mv /tmp/mcp.json /root/.claude/mcp.json
+      jq '.mcpServers["brave-search"].env.BRAVE_API_KEY = "${var_brave_api_key}"' /root/.claude/mcp.json > /tmp/mcp.json && mv /tmp/mcp.json /root/.claude/mcp.json
     fi
     cp -a /root/.claude /etc/skel
     cp -a /root/.digrc /etc/skel


### PR DESCRIPTION
## Summary
- Replace `jq --in-place` with safer temp file approach for JSON manipulation
- Prevent potential data corruption during API key injection in cloud-init
- Follow atomic update pattern for better reliability

## Changes
- Modified `cloud-init/CLOUDSHELL.conf` to use temp file pattern for jq operations
- Ensures atomic updates to `/root/.claude/mcp.json` configuration
- Maintains data integrity during Perplexity and Brave API key injection

## Test Plan
- [x] Verified jq syntax and temp file approach
- [x] Confirmed atomic update pattern follows best practices
- [x] Validated against cloud-init script execution flow

## Risk Assessment
Low risk - This improves safety of existing functionality without changing behavior.

🤖 Generated with [Claude Code](https://claude.ai/code)