### PR TITLE
feat: add GitHub MCP Server to cloud-init configuration

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -602,6 +602,7 @@ runcmd:
     docker pull mcp/filesystem:latest
     docker pull kubernetes-mcp-server@latest
     docker pull hashicorp/terraform-mcp-server:latest
+    docker pull ghcr.io/github/github-mcp-server
     usermod -aG docker ${var_admin_username}
   - |
     # Enable NVIDIA persistence daemon for stable GPU memory management


### PR DESCRIPTION
## Summary
- Added docker pull for `ghcr.io/github/github-mcp-server` to CloudShell cloud-init configuration
- Ensures GitHub MCP server is available in the CloudShell environment for enhanced GitHub integration

## Changes
- Modified `cloud-init/CLOUDSHELL.conf` to include GitHub MCP server container pull

## Testing
- [x] Configuration syntax validated
- [x] Follows existing pattern for MCP server additions
- [x] No breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)