### PR TITLE
feat: add opal-security npm package and lacework iac scan initialization

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -272,6 +272,7 @@ write_files:
         markdownlint-cli
         markdownlint-cli2
         newman
+        opal-security
         playwright
         prettier
         puppeteer
@@ -560,6 +561,7 @@ runcmd:
     lacework component install iac
     lacework component install remediate
     lacework component install vuln-scanner
+    mkdir /root/tmp && cd /root/tmp && lacework iac scan && cd -
   - curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash -s --
   - |
     export HOME=/root/.ollama && curl -fsSL https://ollama.com/install.sh | sh


### PR DESCRIPTION
## Summary
- Added opal-security to npm global packages for enhanced security scanning capabilities
- Added initialization command to create /root/tmp directory and run lacework iac scan during cloud-init

## Changes
- Updated `cloud-init/CLOUDSHELL.conf` to include:
  - `opal-security` in the npm packages list
  - Lacework IaC scan initialization in the runcmd section

## Testing
- [x] Changes validated in cloud-init configuration format
- [x] Syntax verified for bash commands

🤖 Generated with [Claude Code](https://claude.ai/code)