### PR TITLE
feat: update CloudShell SuperClaude installation to developer profile

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -736,10 +736,10 @@ runcmd:
     echo "Setting up SuperClaude framework..."
     if command -v SuperClaude >/dev/null 2>&1; then
         echo "SuperClaude command found, attempting framework installation..."
-        if SuperClaude install --quick; then
+        if SuperClaude install --profile developer; then
             echo "SuperClaude framework installed successfully"
         else
-            echo "WARNING: SuperClaude install --quick failed, continuing without framework setup" >&2
+            echo "WARNING: SuperClaude install --profile developer failed, continuing without framework setup" >&2
             # Log the failure but don't exit - this is not critical for VM operation
         fi
     else


### PR DESCRIPTION
## Summary
- Updated SuperClaude installation in CloudShell configuration from `--quick` to `--profile developer`
- This provides more comprehensive development tools in the CloudShell environment

## Changes
- Modified `cloud-init/CLOUDSHELL.conf` to use developer profile for SuperClaude installation
- Updated corresponding error message

## Testing
- [x] terraform fmt passes
- [x] terraform validate passes
- [x] No impact on existing infrastructure resources