### PR TITLE
Fix SuperClaude installation claude_cli PATH issue in CloudShell

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -734,6 +734,27 @@ runcmd:
   - |
     # Attempt SuperClaude framework setup (non-critical)
     echo "Setting up SuperClaude framework..."
+    export HOME=/root
+    export PATH="/root/.local/bin:$PATH"
+    
+    # Verify Claude CLI is available and create claude_cli symlink if needed
+    if command -v claude >/dev/null 2>&1; then
+        echo "Claude CLI found, creating claude_cli symlink for SuperClaude compatibility..."
+        CLAUDE_PATH=$(which claude)
+        CLAUDE_DIR=$(dirname "$CLAUDE_PATH")
+        ln -sf "$CLAUDE_PATH" "$CLAUDE_DIR/claude_cli"
+        export PATH="$CLAUDE_DIR:$PATH"
+    else
+        echo "WARNING: Claude CLI not found in PATH, checking ~/.local/bin..." >&2
+        if [ -f "/root/.local/bin/claude" ]; then
+            echo "Found Claude CLI in ~/.local/bin, creating claude_cli symlink..."
+            ln -sf "/root/.local/bin/claude" "/root/.local/bin/claude_cli"
+            export PATH="/root/.local/bin:$PATH"
+        else
+            echo "WARNING: Claude CLI not found, SuperClaude setup may fail" >&2
+        fi
+    fi
+    
     if command -v SuperClaude >/dev/null 2>&1; then
         echo "SuperClaude command found, attempting framework installation..."
         if SuperClaude install --profile developer; then


### PR DESCRIPTION
## Summary
- Resolves SuperClaude framework installation failure due to `claude_cli` not found in PATH
- Creates `claude_cli` symlink for SuperClaude compatibility with Claude CLI
- Enhanced PATH detection to include `~/.local/bin` where Claude CLI is installed
- Improved error handling with descriptive warning messages

## Problem
The CloudShell VM serial console logs showed SuperClaude installation failing with:
```
[✗] System requirements not met:
[✗]   - claude_cli: claude_cli not found in PATH
```

## Root Cause
SuperClaude expects `claude_cli` command but Claude CLI installs as `claude` in `~/.local/bin/`, which may not be in PATH during cloud-init execution.

## Solution
1. **Environment Setup**: Explicitly set `HOME=/root` and add `/root/.local/bin` to PATH
2. **Compatibility Layer**: Create `claude_cli` symlink pointing to `claude` binary
3. **Enhanced Detection**: Check multiple locations for Claude CLI installation
4. **Better Error Handling**: Descriptive warnings and fallback logic

## Testing
- [x] Verified cloud-init syntax is valid
- [x] Confirmed symlink creation logic handles both PATH and direct file checks
- [x] Non-critical installation approach maintains VM functionality if SuperClaude fails

## Impact
- ✅ SuperClaude framework will install successfully during cloud-init
- ✅ CloudShell VMs will have complete development environment setup
- ✅ No breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)