### PR TITLE
chore(pre-commit): migrate from tfsec to terraform_trivy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,8 +18,10 @@ repos:
         args:
           - --args=--disable-rule=terraform_standard_module_structure
           - --args=--format=json
-      - id: terraform_tfsec
-        args: [--args=--config-file=./.tfsec.yml]
+      - id: terraform_trivy
+        args:
+          - --args=--severity=CRITICAL,HIGH
+          - --args=--config=./.trivy-config.yaml
       - id: terraform_docs
         args: ["--hook-config=--path-to-file=README.md", "--hook-config=--add-to-existing-file=true"]
 

--- a/.trivy-config.yaml
+++ b/.trivy-config.yaml
@@ -1,0 +1,14 @@
+vulnerability:
+  ignore-unfixed: true
+  severity: [CRITICAL, HIGH]
+
+misconfiguration:
+  include-non-failures: false
+  severity: [CRITICAL, HIGH]
+
+# Map tfsec-equivalent checks to trivy policy where applicable
+# You can add ignore rules here if certain findings are acceptable by design
+# e.g.
+# ignore-policy:
+#   - id: AZU001 # example ID
+#     reason: "Justification here"

--- a/monitoring-enhanced.tf
+++ b/monitoring-enhanced.tf
@@ -250,6 +250,7 @@ resource "azurerm_storage_account" "nsg_flow_logs" {
   account_tier             = "Standard"
   account_replication_type = "LRS"
   account_kind             = "StorageV2"
+  min_tls_version          = "TLS1_2"
 
   blob_properties {
     delete_retention_policy {


### PR DESCRIPTION
- Replace terraform_tfsec hook with terraform_trivy
- Add .trivy-config.yaml (CRITICAL,HIGH severities; ignore-unfixed)
- Remove .tfsec.yml

Note: trivy currently reports AVD-AZU-0041 (AKS API IP ranges). Will address in follow-up.