### PR TITLE
Fix SuperClaude non-interactive installation in cloud-init

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -756,7 +756,8 @@ runcmd:
 
     if command -v SuperClaude >/dev/null 2>&1; then
         echo "SuperClaude command found, attempting framework installation..."
-        if SuperClaude install --profile developer; then
+        # Use echo "y" to automatically answer yes to the prompt about existing installation
+        if echo "y" | SuperClaude install --profile developer; then
             echo "SuperClaude framework installed successfully"
         else
             echo "WARNING: SuperClaude install --profile developer failed, continuing without framework setup" >&2


### PR DESCRIPTION
## Summary
- Fixed SuperClaude installation failing during cloud-init due to interactive prompt
- Added `echo "y" |` to automatically answer 'y' to the SuperClaude installation prompt
- Includes explanatory comment for clarity on the non-interactive approach

## Problem
The SuperClaude installation was failing in the cloud-init environment because it presented an interactive prompt that couldn't be answered in the automated, non-interactive context of VM provisioning.

## Solution
Modified the SuperClaude install command in `/cloud-init/CLOUDSHELL.conf` to pipe 'y' into the command:
```bash
# Before
SuperClaude install --profile developer

# After  
echo "y" | SuperClaude install --profile developer
```

## Test Plan
- [x] Verified syntax and formatting with terraform validation
- [x] Confirmed change addresses the non-interactive installation requirement
- [ ] Test deployment in cloud-init environment to verify installation succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)