### PR TITLE
fix(cloud-init): update dotfiles installation to use cloud-init flag

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -525,7 +525,7 @@ runcmd:
     export DOTFILES_USER=root
     export HOME=/root
     chmod +x ./install.sh
-    ./install.sh
+    bash install.sh --cloud-init
     cd -
   - |
     mkdir -p /root/.kube/


### PR DESCRIPTION
## Summary
- Updated CLOUDSHELL.conf to use `bash install.sh --cloud-init` instead of `./install.sh`
- Ensures proper cloud-init execution context detection in the dotfiles installation process
- Improves multi-user environment handling for Azure CloudShell deployments

## Changes
- Line 528 in `cloud-init/CLOUDSHELL.conf`: Changed from `./install.sh` to `bash install.sh --cloud-init`

## Test plan
- [ ] Verify cloud-init configuration syntax is valid
- [ ] Test deployment in CloudShell environment to ensure dotfiles install correctly
- [ ] Confirm no regression in existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)