### PR TITLE
chore: update pre-commit utility versions to latest stable releases

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -10,7 +10,7 @@ repos:
       - id: check-added-large-files
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.88.0
+    rev: v1.100.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -27,7 +27,7 @@ repos:
         args: ["--hook-config=--path-to-file=README.md", "--hook-config=--add-to-existing-file=true"]
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.42.0
+    rev: v0.43.0
     hooks:
       - id: markdownlint
         args: ["--disable", "MD013", "MD033", "MD041"]


### PR DESCRIPTION
## Summary
Consolidates multiple issue #196 branches into a single clean commit that updates pre-commit utility versions to their latest stable releases.

## Changes
- **pre-commit-hooks**: v4.6.0 → v5.0.0
- **pre-commit-terraform**: v1.88.0 → v1.100.0  
- **markdownlint-cli**: v0.42.0 → v0.43.0

## Context
Multiple branches were accidentally created for issue #196 with similar changes. This PR consolidates all the relevant changes into a single, clean commit.

## Testing
- [x] Terraform validation passes
- [x] Changes are focused and minimal
- [x] No breaking changes introduced

Closes #196

🤖 Generated with [Claude Code](https://claude.ai/code)