### PR TITLE
feat: add @qwen-code/qwen-code@latest to CloudShell npm packages

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -258,6 +258,7 @@ write_files:
         @modelcontextprotocol/server-sequential-thinking
         @azure/mcp@latest
         @21st-dev/magic@latest
+        @qwen-code/qwen-code@latest
         bash-language-server
         claude-auto-commit
         cwebp


### PR DESCRIPTION
## Summary
Adds `@qwen-code/qwen-code@latest` to the global npm packages installed during CloudShell VM provisioning.

## Changes
- Added `@qwen-code/qwen-code@latest` to `GLOBAL_NPM_PACKAGES` array in `npm-install.sh` script
- Package will be installed globally during the cloud-init process
- Enhances CloudShell development environment with Qwen Code capabilities

## Context
This addition expands the available development tools in the CloudShell environment by including the Qwen Code package, which provides AI-powered coding assistance capabilities.

## Testing
- [x] Added package to the npm packages array
- [x] Verified syntax and formatting
- [x] No breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)