### PR TITLE
fix(cloud-init): handle double prompt in SuperClaude installation

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -757,8 +757,10 @@ runcmd:
 
     if command -v SuperClaude >/dev/null 2>&1; then
         echo "SuperClaude command found, attempting framework installation..."
-        # Use echo "y" to automatically answer yes to the prompt about existing installation
-        if echo "y" | SuperClaude install --profile developer; then
+        # Use printf to provide "y" answers to both prompts:
+        # 1. "Continue and update existing installation?"
+        # 2. "Proceed with installation?"
+        if printf "y\ny\n" | SuperClaude install --profile developer; then
             echo "SuperClaude framework installed successfully"
         else
             echo "WARNING: SuperClaude install --profile developer failed, continuing without framework setup" >&2


### PR DESCRIPTION
## Summary
- Fixed SuperClaude installation script to handle both confirmation prompts
- Changed from `echo "y"` to `printf "y\ny\n"` to provide both required responses

## Issue
The SuperClaude installation was failing because it requires two separate confirmations:
1. "Continue and update existing installation?" 
2. "Proceed with installation?"

The previous implementation only provided one "y" response, causing the installation to hang waiting for the second response.

## Solution
Updated the cloud-init script to use `printf "y\ny\n"` which provides both "y" responses needed for the installation to proceed automatically.

## Test Plan
- [ ] Deploy CloudShell VM with updated cloud-init
- [ ] Verify SuperClaude installation completes without hanging
- [ ] Confirm SuperClaude framework is available after boot

🤖 Generated with [Claude Code](https://claude.ai/code)