### PR TITLE
fix(workflow): add missing Claude Code OAuth token environment variable

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -145,6 +145,7 @@ jobs:
           TF_VAR_letsencrypt_url: ${{ vars.LETSENCRYPT_URL }}
           TF_VAR_brave_api_key: ${{ secrets.BRAVE_API_KEY }}
           TF_VAR_perplexity_api_key: ${{ secrets.PERPLEXITY_API_KEY }}
+          TF_VAR_claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           TF_IN_AUTOMATION: true
         run: |
           export exitcode=0
@@ -270,6 +271,7 @@ jobs:
           TF_VAR_letsencrypt_url: ${{ vars.LETSENCRYPT_URL }}
           TF_VAR_brave_api_key: ${{ secrets.BRAVE_API_KEY }}
           TF_VAR_perplexity_api_key: ${{ secrets.PERPLEXITY_API_KEY }}
+          TF_VAR_claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           TF_IN_AUTOMATION: true
           GH_TOKEN: ${{ secrets.PAT }}
         run: terraform apply -auto-approve tfplan
@@ -371,6 +373,7 @@ jobs:
           TF_VAR_letsencrypt_url: ${{ vars.LETSENCRYPT_URL }}
           TF_VAR_brave_api_key: ${{ secrets.BRAVE_API_KEY }}
           TF_VAR_perplexity_api_key: ${{ secrets.PERPLEXITY_API_KEY }}
+          TF_VAR_claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           TF_IN_AUTOMATION: true
         run: |
           terraform destroy -auto-approve


### PR DESCRIPTION
## Summary
This PR resolves critical infrastructure deployment failures by adding the missing `TF_VAR_claude_code_oauth_token` environment variable mapping to all GitHub Actions workflow jobs.

## Problem Statement
Issue #205 identified that infrastructure deployments were failing with the error:
```
Error: No value for required variable
  on variables.tf line 534:
 534: variable "claude_code_oauth_token" {

The root module input variable "claude_code_oauth_token" is not set, and has
no default value.
```

## Root Cause Analysis
The Claude Code OAuth token integration was implemented in PR #204 with:
- ✅ Variable definition in `variables.tf` (lines 534-538)  
- ✅ Template integration in `cloudshell.tf` (line 239)
- ✅ Cloud-init credentials file creation in `cloud-init/CLOUDSHELL.conf` (lines 814-821)
- ❌ **Missing**: GitHub workflow environment variable mappings

## Changes Made
Added `TF_VAR_claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}` to all three workflow jobs:

### 1. Terraform Plan Job (line 148)
```yaml
TF_VAR_perplexity_api_key: ${{ secrets.PERPLEXITY_API_KEY }}
TF_VAR_claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}  # ADDED
TF_IN_AUTOMATION: true
```

### 2. Terraform Apply Job (line 274)  
```yaml
TF_VAR_perplexity_api_key: ${{ secrets.PERPLEXITY_API_KEY }}
TF_VAR_claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}  # ADDED
TF_IN_AUTOMATION: true
```

### 3. Terraform Destroy Job (line 376)
```yaml
TF_VAR_perplexity_api_key: ${{ secrets.PERPLEXITY_API_KEY }}
TF_VAR_claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}  # ADDED
TF_IN_AUTOMATION: true
```

## Security Compliance
- ✅ Variable marked as `sensitive = true` in variables.tf
- ✅ Uses GitHub secrets for secure token storage
- ✅ Follows established patterns for sensitive variables (brave_api_key, perplexity_api_key)
- ✅ Maintains OAuth token security in CloudShell credential files (600 permissions)

## Testing
- ✅ `terraform fmt` - Formatting validated
- ✅ `terraform init -backend=false` - Initialization successful  
- ✅ `terraform validate` - Configuration valid
- ✅ All changes follow Terraform and workflow best practices

## Impact Resolution
This fix resolves:
- 🔧 **Infrastructure deployment blocker** - All deployments currently failing
- 🔧 **CloudShell Claude Code integration** - OAuth authentication will work properly
- 🔧 **CI/CD pipeline health** - Workflow can proceed with complete variable set

## Next Steps Required
**Repository administrator must add the GitHub secret**:
```
Settings → Secrets and variables → Actions → New repository secret
Name: CLAUDE_CODE_OAUTH_TOKEN
Value: [OAuth token value from Claude Code]
```

## Acceptance Criteria
- [x] Environment variable added to all three workflow jobs
- [x] Variable names match Terraform convention (`TF_VAR_*`)
- [x] Secret reference follows GitHub Actions pattern
- [x] Terraform validation passes
- [x] No breaking changes introduced
- [x] Security best practices maintained

## Related Issues
- Fixes #205 - add claude code credentials
- Builds on PR #204 - feat(cloudshell): add Claude Code OAuth token integration

🤖 Generated with [Claude Code](https://claude.ai/code)