### PR TITLE
Fix Terraform template variable escaping in cloud-init script

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -188,7 +188,7 @@ write_files:
           echo "[SUCCESS] VS Code: Extension '$EXT' installed successfully"
         else
           echo "[ERROR] VS Code: Failed to install extension '$EXT' - continuing with other extensions"
-          FAILED_EXTENSIONS="${FAILED_EXTENSIONS}vscode:$EXT "
+          FAILED_EXTENSIONS="$${FAILED_EXTENSIONS}vscode:$EXT "
           OVERALL_SUCCESS=1
         fi
         
@@ -200,7 +200,7 @@ write_files:
           SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
         else
           echo "[ERROR] VS Code Insiders: Failed to install extension '$EXT' - continuing with other extensions"
-          FAILED_EXTENSIONS="${FAILED_EXTENSIONS}vscode-insiders:$EXT "
+          FAILED_EXTENSIONS="$${FAILED_EXTENSIONS}vscode-insiders:$EXT "
           OVERALL_SUCCESS=1
         fi
       done


### PR DESCRIPTION
## Summary
This PR fixes a critical Terraform template escaping issue that was causing GitHub Actions infrastructure workflow to fail.

## Problem
The cloud-init script (CLOUDSHELL.conf) contains bash variables that were not properly escaped for Terraform's templatefile() function. Specifically, the `FAILED_EXTENSIONS` variable was interpreted by Terraform as a template variable, causing the error:
```
Invalid value for 'vars' parameter: vars map does not contain key 'FAILED_EXTENSIONS'
```

## Solution
Escaped the dollar signs in bash variables using `$$` notation so Terraform passes them through as literal bash variables instead of trying to interpret them as template variables.

## Changes
- Fixed `${FAILED_EXTENSIONS}` → `$${FAILED_EXTENSIONS}` in two locations (lines 191 and 203)

## Testing
- [x] terraform fmt passes
- [x] terraform validate passes
- [x] Verified all other bash variables in the file are already properly escaped

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>