### PR TITLE
Fix cloud-init script syntax errors causing premature exit

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -29,10 +29,15 @@ bootcmd:
       done
 
       if [ "$always_format" = "yes" ]; then
-        echo "[INFO] Formatting $dev (forced) for $mount_point ..."
-        wipefs -a "$dev" 2>/dev/null || true  # Complete filesystem signature wipe
-        parted -s "$dev" mklabel gpt mkpart primary ext4 0% 100%
-        mkfs.ext4 -F "$part" -L "$label"
+        # Check if the partition is currently mounted
+        if mount | grep -q "$part"; then
+          echo "[INFO] $part is currently mounted, skipping format to prevent data loss"
+        else
+          echo "[INFO] Formatting $dev (forced) for $mount_point ..."
+          wipefs -a "$dev" 2>/dev/null || true  # Complete filesystem signature wipe
+          parted -s "$dev" mklabel gpt mkpart primary ext4 0% 100%
+          mkfs.ext4 -F "$part" -L "$label"
+        fi
       else
         if ! blkid "$part" >/dev/null 2>&1; then
           echo "[INFO] No filesystem on $dev — formatting for $mount_point ..."
@@ -732,8 +737,8 @@ runcmd:
       
       # Install Lacework components with error handling
       echo "[INFO] Installing Lacework components..."
-      LACEWORK_COMPONENTS=("sca" "iac" "remediate" "vuln-scanner")
-      for COMPONENT in "$${LACEWORK_COMPONENTS[@]}"; do
+      LACEWORK_COMPONENTS="sca iac remediate vuln-scanner"
+      for COMPONENT in $LACEWORK_COMPONENTS; do
         echo "[INFO] Installing Lacework component: $COMPONENT"
         if lacework component install "$COMPONENT"; then
           echo "[SUCCESS] Installed Lacework component: $COMPONENT"
@@ -766,8 +771,8 @@ runcmd:
       
       # Pull Ollama models with error handling
       echo "[INFO] Pulling Ollama models..."
-      OLLAMA_MODELS=("deepseek-r1:latest" "gpt-oss:20b")
-      for MODEL in "$${OLLAMA_MODELS[@]}"; do
+      OLLAMA_MODELS="deepseek-r1:latest gpt-oss:20b"
+      for MODEL in $OLLAMA_MODELS; do
         echo "[INFO] Pulling Ollama model: $MODEL"
         if ollama pull "$MODEL"; then
           echo "[SUCCESS] Pulled Ollama model: $MODEL"
@@ -816,20 +821,10 @@ runcmd:
   - |
     # Pull Docker images with error handling
     echo "[INFO] Pulling Docker container images..."
-    DOCKER_IMAGES=(
-      "ghcr.io/40docs/devcontainer:latest"
-      "mcp/memory:latest"
-      "mcp/git:latest"
-      "mcp/time:latest"
-      "mcp/sequentialthinking:latest"
-      "mcp/filesystem:latest"
-      "kubernetes-mcp-server@latest"
-      "hashicorp/terraform-mcp-server:latest"
-      "ghcr.io/github/github-mcp-server"
-    )
+    DOCKER_IMAGES="ghcr.io/40docs/devcontainer:latest mcp/memory:latest mcp/git:latest mcp/time:latest mcp/sequentialthinking:latest mcp/filesystem:latest kubernetes-mcp-server@latest hashicorp/terraform-mcp-server:latest ghcr.io/github/github-mcp-server"
     
     FAILED_PULLS=""
-    for IMAGE in "$${DOCKER_IMAGES[@]}"; do
+    for IMAGE in $DOCKER_IMAGES; do
       echo "[INFO] Pulling Docker image: $IMAGE"
       if docker pull "$IMAGE" 2>&1; then
         echo "[SUCCESS] Pulled: $IMAGE"


### PR DESCRIPTION
## Summary
This PR fixes bash array syntax incompatibility in CLOUDSHELL.conf that caused the cloud-init script to exit prematurely at line 735.

## Issues Fixed
1. **Syntax Error at line 735**: Replaced bash array syntax `ARRAY=(item1 item2)` with POSIX-compatible `ARRAY="item1 item2"` for:
   - Lacework components array
   - Ollama models array  
   - Docker images array

2. **Disk Formatting Error**: Added mount check before formatting to prevent data loss on subsequent boots

## Impact
- Fixes cloud-init script execution failures
- Allows all tools and configurations to be properly installed during VM initialization
- Prevents data loss from formatting mounted partitions

## Testing
- [x] Syntax validated for POSIX shell compatibility
- [x] Changes are backward compatible
- [x] No breaking changes to existing functionality

This resolves the issue where cloud-init would fail with 'Syntax error: "(" unexpected (expecting "fi")' and exit before completing the full installation.