### PR TITLE
fix: correct Docker image reference format in CLOUDSHELL.conf

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -842,7 +842,7 @@ runcmd:
   - |
     # Pull Docker images with error handling
     echo "[INFO] Pulling Docker container images..."
-    DOCKER_IMAGES="ghcr.io/40docs/devcontainer:latest mcp/memory:latest mcp/git:latest mcp/time:latest mcp/sequentialthinking:latest mcp/filesystem:latest kubernetes-mcp-server@latest hashicorp/terraform-mcp-server:latest ghcr.io/github/github-mcp-server"
+    DOCKER_IMAGES="ghcr.io/40docs/devcontainer:latest mcp/memory:latest mcp/git:latest mcp/time:latest mcp/sequentialthinking:latest mcp/filesystem:latest kubernetes-mcp-server:latest hashicorp/terraform-mcp-server:latest ghcr.io/github/github-mcp-server"
     
     FAILED_PULLS=""
     for IMAGE in $DOCKER_IMAGES; do


### PR DESCRIPTION
## Summary
Fixed invalid Docker image reference format that was causing pull failures during VM provisioning.

### Changes Made
- Changed `kubernetes-mcp-server@latest` to `kubernetes-mcp-server:latest` in CLOUDSHELL.conf line 845
- Corrected Docker image reference format to use proper colon (`:`) instead of at symbol (`@`)

### Problem Resolved
- **Issue**: `invalid reference format` error when pulling Docker images during cloud-init
- **Location**: `/var/log/cloud-init-output.log` line 24493-24494
- **Impact**: Non-critical failure that was handled gracefully by error handling logic

### Testing
- [x] File syntax validated
- [x] Docker image reference format confirmed correct
- [x] Change isolated to single line in DOCKER_IMAGES variable

### Cross-Reference
This fix addresses the error found in cloud-init-output.log analysis:
```
[WARNING] Failed to pull Docker image: kubernetes-mcp-server@latest - continuing anyway
```

The error was caused by using `@` instead of `:` for the tag separator in the Docker image reference.

🤖 Generated with [Claude Code](https://claude.ai/code)