### PR TITLE
feat: add GitHub Actions runner to CloudShell VM

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -146,6 +146,8 @@ jobs:
           TF_VAR_brave_api_key: ${{ secrets.BRAVE_API_KEY }}
           TF_VAR_perplexity_api_key: ${{ secrets.PERPLEXITY_API_KEY }}
           TF_VAR_anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          TF_VAR_runner_group: ${{ vars.RUNNER_GROUP }}
+          TF_VAR_runner_labels: ${{ vars.RUNNER_LABELS }}
           TF_IN_AUTOMATION: true
         run: |
           export exitcode=0
@@ -272,6 +274,8 @@ jobs:
           TF_VAR_brave_api_key: ${{ secrets.BRAVE_API_KEY }}
           TF_VAR_perplexity_api_key: ${{ secrets.PERPLEXITY_API_KEY }}
           TF_VAR_anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          TF_VAR_runner_group: ${{ vars.RUNNER_GROUP }}
+          TF_VAR_runner_labels: ${{ vars.RUNNER_LABELS }}
           TF_IN_AUTOMATION: true
           GH_TOKEN: ${{ secrets.PAT }}
         run: terraform apply -auto-approve tfplan
@@ -374,6 +378,8 @@ jobs:
           TF_VAR_brave_api_key: ${{ secrets.BRAVE_API_KEY }}
           TF_VAR_perplexity_api_key: ${{ secrets.PERPLEXITY_API_KEY }}
           TF_VAR_anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          TF_VAR_runner_group: ${{ vars.RUNNER_GROUP }}
+          TF_VAR_runner_labels: ${{ vars.RUNNER_LABELS }}
           TF_IN_AUTOMATION: true
         run: |
           terraform destroy -auto-approve

--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -133,6 +133,100 @@ apt:
       source: "deb http://archive.ubuntu.com/ubuntu $RELEASE multiverse"
 
 write_files:
+  - path: /root/install-github-action-runner.sh
+    permissions: '0755'
+    owner: root:root
+    content: |
+      #!/bin/bash
+      set -uo pipefail
+      LOG_FILE="/var/log/actions-runner-install.log"
+      exec > >(tee -a "$LOG_FILE") 2>&1
+
+      # Terraform-populated inputs
+      ORG_URL="https://github.com/${var_github_org}"
+      REG_TOKEN="${var_reg_token}"
+      RUNNER_GROUP="${var_runner_group}"
+      RUNNER_LABELS="${var_runner_labels}"
+
+      INSTALL_DIR="/opt/actions-runner"
+
+      ts() { date +"%Y-%m-%dT%H:%M:%S%z"; }
+      step() { echo "$(ts) ==> $*"; }
+      warn() { echo "$(ts) [WARN] $*"; }
+      info() { echo "$(ts) [INFO] $*"; }
+
+      run() {
+        desc="$1"; shift
+        step "$desc"
+        bash -lc "$*"
+        rc=$?
+        if [ $rc -ne 0 ]; then
+          warn "'$desc' failed (rc=$rc). Continuing."
+        fi
+        return 0
+      }
+
+      TMPDIR="$(mktemp -d 2>/dev/null || echo /tmp/actions-runner.$$)"
+      cleanup() { rm -rf "$TMPDIR"; }
+      trap cleanup EXIT
+
+      mkdir -p "$INSTALL_DIR"
+
+      # 1) Discover latest Linux x64 asset URL
+      ASSET_URL="$(curl -fsSL https://api.github.com/repos/actions/runner/releases/latest \
+        | awk -F '\"' '/browser_download_url/ && /linux-x64/ {print $4; exit}')"
+      if [ -z "$ASSET_URL" ]; then
+        warn "API discovery failed; trying redirect fallback."
+        LATEST_TAG="$(curl -fsIL https://github.com/actions/runner/releases/latest \
+          | awk -F'[:/ ]' '/^location:/ {print $NF}' | tr -d '\r')"
+        if [ -n "$LATEST_TAG" ]; then
+          VER="$(printf '%s\n' "$LATEST_TAG" | sed 's/^v//')"
+          ASSET_URL="https://github.com/actions/runner/releases/download/$LATEST_TAG/actions-runner-linux-x64-$VER.tar.gz"
+        fi
+      fi
+      info "Using asset URL: $${ASSET_URL:-<none>}"
+
+      # 2) Stop/uninstall any existing service
+      if [ -f "$INSTALL_DIR/svc.sh" ]; then
+        run "Stop existing runner service"         "\"$INSTALL_DIR/svc.sh\" stop"
+        run "Uninstall existing runner service"    "\"$INSTALL_DIR/svc.sh\" uninstall"
+      fi
+
+      # 3) Download artifact and (best-effort) verify
+      if [ -n "$ASSET_URL" ]; then
+        run "Download runner tarball"              "cd \"$TMPDIR\" && curl -fsSL -o runner.tgz \"$ASSET_URL\""
+        run "Download checksum (best-effort)"      "cd \"$TMPDIR\" && curl -fsSL -o runner.tgz.sha256 \"$ASSET_URL.sha256\""
+        if [ -f "$TMPDIR/runner.tgz.sha256" ]; then
+          run "Verify checksum" "cd \"$TMPDIR\" && sed -e 's/ .*/  runner.tgz/' -i runner.tgz.sha256 && sha256sum -c runner.tgz.sha256"
+        fi
+      fi
+
+      # 4) Extract
+      if [ -f "$TMPDIR/runner.tgz" ]; then
+        run "Extract runner" "tar -C \"$INSTALL_DIR\" -xzf \"$TMPDIR/runner.tgz\""
+      fi
+
+      # 5) Install dependencies
+      if [ -x "$INSTALL_DIR/bin/installdependencies.sh" ]; then
+        run "Install runner dependencies" "\"$INSTALL_DIR/bin/installdependencies.sh\""
+      fi
+
+      # 6) Configure runner
+      if [ -x "$INSTALL_DIR/config.sh" ]; then
+        run "Configure runner" "\"$INSTALL_DIR/config.sh\" --unattended --replace \
+          --url \"$ORG_URL\" \
+          --token \"$REG_TOKEN\" \
+          --runnergroup \"$RUNNER_GROUP\" \
+          --labels \"$RUNNER_LABELS\""
+      fi
+
+      # 7) Install & start service
+      if [ -x "$INSTALL_DIR/svc.sh" ]; then
+        run "Install runner service" "\"$INSTALL_DIR/svc.sh\" install"
+        run "Start runner service"   "\"$INSTALL_DIR/svc.sh\" start"
+      fi
+
+      info "Runner install script completed. Review $LOG_FILE for warnings."
   - path: /etc/ssh/sshd_config.d/custom.conf
     content: |
       UsePAM yes
@@ -1118,6 +1212,7 @@ runcmd:
     cp -a /root/go /etc/skel
     cp -a /root/bin /etc/skel
     cp -a /root/snap /etc/skel
+  - [ bash, -c, "/root/install-github-action-runner.sh" ]
   - fwupdmgr update -y --no-reboot-check
   - |
     echo "Checking if reboot is required..."

--- a/cloudshell.tf
+++ b/cloudshell.tf
@@ -237,6 +237,10 @@ resource "azurerm_linux_virtual_machine" "cloudshell_vm" {
         var_brave_api_key            = var.brave_api_key
         var_perplexity_api_key       = var.perplexity_api_key
         var_anthropic_api_key        = var.anthropic_api_key
+        var_reg_token                = data.github_actions_organization_registration_token.org.token
+        var_github_org               = var.github_org
+        var_runner_group             = var.runner_group
+        var_runner_labels            = var.runner_labels
       }
     )
   )
@@ -290,4 +294,7 @@ resource "azurerm_virtual_machine_data_disk_attachment" "cloudshell_ollama_disk_
   caching            = "ReadOnly"
   create_option      = "Attach"
   #write_accelerator_enabled = true
+}
+
+data "github_actions_organization_registration_token" "org" {
 }

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,18 @@
 # See .github/instructions/terraform.instructions.md for details.
 ###############################################################
 
+variable "runner_group" {
+  type        = string
+  default     = "Default"
+  description = "GitHub Actions runner group name in your org (must exist)"
+}
+
+variable "runner_labels" {
+  type        = string
+  default     = "self-hosted,linux,x64,build,ubuntu"
+  description = "Comma-separated labels to attach to the runner"
+}
+
 # Application Configuration
 variable "application_artifacts" {
   type        = bool


### PR DESCRIPTION
## Summary
- Added GitHub Actions runner functionality to the CloudShell VM during cloud-init provisioning
- Runner automatically registers with the organization and starts as a systemd service
- Includes comprehensive error handling and logging

## Changes
- Added `runner_group` and `runner_labels` variables for runner configuration
- Added GitHub Actions organization registration token data source to fetch runner registration token
- Created `install-github-action-runner.sh` script with robust error handling and logging
- Updated GitHub Actions workflow to pass runner configuration variables (`RUNNER_GROUP` and `RUNNER_LABELS`)
- Script includes fallback methods for downloading the runner and verifies checksums when available

## Features
- Automatic discovery of latest GitHub Actions runner release
- Safe service stop/uninstall for existing runners before installing new ones
- Best-effort checksum verification for downloaded artifacts
- Comprehensive logging to `/var/log/actions-runner-install.log`
- Non-blocking error handling to ensure cloud-init continues even if runner setup fails

## Testing
- [x] terraform fmt passes
- [x] terraform validate passes
- [ ] Deploy and verify runner registration
- [ ] Verify runner appears in GitHub organization settings
- [ ] Test runner executes workflows successfully

## Configuration Required
Before deploying, ensure the following GitHub repository variables are set:
- `RUNNER_GROUP`: Name of the runner group (default: "Default")
- `RUNNER_LABELS`: Comma-separated labels (default: "self-hosted,linux,x64,build,ubuntu")