### PR TITLE
fix: Remove Claude Code npm package from CLOUDSHELL installation

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -447,7 +447,6 @@ write_files:
       # Global npm packages
       GLOBAL_NPM_PACKAGES=(
         @anaisbetts/mcp-installer
-        @anthropic-ai/claude-code
         @modelcontextprotocol/server-memory
         @modelcontextprotocol/server-filesystem
         @modelcontextprotocol/server-brave-search


### PR DESCRIPTION
## Summary
- Removed @anthropic-ai/claude-code from global npm packages in CLOUDSHELL cloud-init configuration
- Claude Code should be installed via the official installer, not npm package

## Context
This corrects the installation method for Claude Code in the CLOUDSHELL VM configuration.

## Testing
- [x] Verified cloud-init configuration syntax
- [x] Confirmed Claude Code installer is still present in the configuration