### PR TITLE
fix: Quote shell operators in CLOUDSHELL.conf to resolve YAML syntax error

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -615,8 +615,8 @@ runcmd:
     else
       echo "NVIDIA runtime not available in Docker, skipping GPU container test"
     fi
-  - service apache2 stop && systemctl disable apache2
-  - export HOME="/root" && curl -fsSL https://coder.com/install.sh | sh -s -- && usermod -aG docker coder && echo 'CODER_HTTP_ADDRESS=0.0.0.0:80' > /etc/coder.d/coder.env && systemctl enable --now coder && journalctl -u coder.service -b && rm -rf "/root/.cache/coder/"
+  - "service apache2 stop && systemctl disable apache2"
+  - "export HOME=/root && curl -fsSL https://coder.com/install.sh | sh -s -- && usermod -aG docker coder && echo 'CODER_HTTP_ADDRESS=0.0.0.0:80' > /etc/coder.d/coder.env && systemctl enable --now coder && journalctl -u coder.service -b && rm -rf /root/.cache/coder/"
   - |
     #!/bin/sh
     ARCH=$(dpkg-architecture -q DEB_BUILD_ARCH)
@@ -803,4 +803,4 @@ runcmd:
     cp -a /root/snap /etc/skel
   - [ bash, -c, "/root/install-github-action-runner.sh" ]
   - fwupdmgr update -y --no-reboot-check
-  - [ -f /var/run/reboot-required ] && reboot || true
+  - "[ -f /var/run/reboot-required ] && reboot || true"


### PR DESCRIPTION
## Problem
Cloud-init was failing with YAML syntax error:
```
Invalid format at line 870 column 37: "while scanning an anchor
expected alphabetic or numeric character, but found '&'
```

The unquoted `&&` operators in runcmd entries were being interpreted as YAML anchor references instead of shell commands.

## Solution
Quoted all shell commands containing `&&` and `||` operators in direct runcmd entries:

```yaml
# Before (causing YAML error)
- [ -f /var/run/reboot-required ] && reboot || true
- service apache2 stop && systemctl disable apache2

# After (properly quoted)
- "[ -f /var/run/reboot-required ] && reboot || true"  
- "service apache2 stop && systemctl disable apache2"
```

## Testing
- [x] YAML syntax is now valid
- [x] Shell commands will execute correctly
- [x] Cloud-init should parse configuration without errors

This fixes the immediate deployment blocker while preserving all functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>