### PR TITLE
Fix GitHub Actions runner bash syntax error in cloud-init

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -146,75 +146,75 @@ write_files:
       RUNNER_GROUP="${var_runner_group}"
       RUNNER_LABELS="${var_runner_labels}"
       INSTALL_DIR="/opt/actions-runner"
-      
+
       # Security: Ensure GitHub token is not logged
       secure_log() {
         local message="$1"
         # Remove any potential token exposure from log messages
         echo "$message" | sed 's/token [a-zA-Z0-9_-]*/token [REDACTED]/g' | tee -a /var/log/cloud-init-output.log
       }
-      
+
       # Validate GitHub token is present
       if [ -z "$GITHUB_TOKEN" ] || [ "$GITHUB_TOKEN" = "null" ]; then
         secure_log "[$(date)] ERROR: GitHub token is missing or invalid"
         exit 1
       fi
-      
+
       # Validate GitHub token has necessary permissions
       validate_github_token() {
         secure_log "[$(date)] Validating GitHub token permissions..."
-        
+
         # Check if token can access the organization
         local org_response=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
           -H "Accept: application/vnd.github.v3+json" \
           "https://api.github.com/orgs/${var_github_org}" 2>/dev/null)
-        
+
         if [ $? -ne 0 ] || [ -z "$org_response" ]; then
           secure_log "[$(date)] ERROR: Cannot access GitHub organization ${var_github_org}"
           return 1
         fi
-        
+
         # Check if token has admin:org permission (required for runners)
         local scopes_response=$(curl -s -I -H "Authorization: token $GITHUB_TOKEN" \
           "https://api.github.com/orgs/${var_github_org}/actions/runners" 2>/dev/null | grep -i "x-oauth-scopes:" || true)
-        
+
         if [ -z "$scopes_response" ]; then
           secure_log "[$(date)] WARNING: Cannot determine token scopes, proceeding anyway"
         else
           secure_log "[$(date)] Token scopes detected: $scopes_response"
         fi
-        
+
         secure_log "[$(date)] GitHub token validation completed"
         return 0
       }
-      
+
       # Validate the GitHub token first
       if ! validate_github_token; then
         secure_log "[$(date)] FATAL: GitHub token validation failed"
         exit 1
       fi
-      
+
       # Function to generate a fresh registration token using GitHub API
       generate_registration_token() {
         local max_attempts=5
         local attempt=1
         local wait_time=10
-        
+
         secure_log "[$(date)] Generating fresh GitHub Actions registration token..."
-        
+
         while [ $attempt -le $max_attempts ]; do
           secure_log "[$(date)] Attempt $attempt of $max_attempts to generate registration token"
-          
+
           # Generate registration token using GitHub API
           local response=$(curl -s -X POST \
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github.v3+json" \
             "https://api.github.com/orgs/${var_github_org}/actions/runners/registration-token" 2>/dev/null)
-          
+
           if [ $? -eq 0 ] && [ -n "$response" ]; then
             # Extract token from JSON response
             REG_TOKEN=$(echo "$response" | jq -r '.token' 2>/dev/null)
-            
+
             if [ "$REG_TOKEN" != "null" ] && [ -n "$REG_TOKEN" ] && [ "$REG_TOKEN" != "" ]; then
               secure_log "[$(date)] Successfully generated registration token"
               return 0
@@ -226,7 +226,7 @@ write_files:
           else
             secure_log "[$(date)] API request failed or returned empty response"
           fi
-          
+
           if [ $attempt -lt $max_attempts ]; then
             secure_log "[$(date)] Waiting $wait_time seconds before retry..."
             sleep $wait_time
@@ -234,11 +234,11 @@ write_files:
           fi
           attempt=$((attempt + 1))
         done
-        
+
         secure_log "[$(date)] ERROR: Failed to generate registration token after $max_attempts attempts"
         return 1
       }
-      
+
       # Generate the registration token
       if ! generate_registration_token; then
         secure_log "[$(date)] FATAL: Cannot proceed without registration token"
@@ -319,20 +319,20 @@ write_files:
       if [ -x "$INSTALL_DIR/config.sh" ]; then
         secure_log "[$(date)] Configuring runner with fresh registration token"
         cd "$INSTALL_DIR"
-        
+
         # Verify the registration token before using it
         if [ -z "$REG_TOKEN" ] || [ "$REG_TOKEN" = "null" ]; then
           secure_log "[$(date)] ERROR: Invalid registration token, cannot configure runner"
           exit 1
         fi
-        
+
         # Configure the runner with retry logic
-        local config_attempts=3
-        local config_attempt=1
-        
+        config_attempts=3
+        config_attempt=1
+
         while [ $config_attempt -le $config_attempts ]; do
           secure_log "[$(date)] Runner configuration attempt $config_attempt of $config_attempts"
-          
+
           if RUNNER_ALLOW_RUNASROOT="1" ./config.sh --unattended --replace --url "$ORG_URL" --token "$REG_TOKEN" --runnergroup "$RUNNER_GROUP" --labels "$RUNNER_LABELS"; then
             secure_log "[$(date)] Runner configuration successful"
             break


### PR DESCRIPTION
## Summary
- Fixed bash syntax error in `cloud-init/CLOUDSHELL.conf` where `local` keywords were used outside of function scope
- Removed `local` keyword from lines 330-331 in the GitHub Actions runner configuration section
- This resolves runner installation failures that were preventing proper CI/CD integration

## Problem
The cloud-init script was failing during GitHub Actions runner installation due to improper use of the `local` keyword outside of function scope. In bash, `local` can only be used within functions, but it was being used in the main script body.

## Solution
```bash
# Before (causing syntax error):
local config_attempts=3
local config_attempt=1

# After (correct syntax):
config_attempts=3
config_attempt=1
```

## Testing
- [x] Terraform syntax validation passes
- [x] Pre-commit hooks pass (including trailing whitespace cleanup)
- [x] Cloud-init script should now execute without bash syntax errors

## Impact
This fix ensures that the CLOUDSHELL VM can properly install and configure GitHub Actions runners, enabling automated CI/CD workflows to function correctly.

🤖 Generated with [Claude Code](https://claude.ai/code)