### PR TITLE
Optimize cloudshell VM size for cost reduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1017,7 +1017,6 @@ No modules.
 | [azurerm_public_ip.hub_nva_vip_ollama_public_ip](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/public_ip) | data source |
 | [azurerm_public_ip.hub_nva_vip_pretix_public_ip](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/public_ip) | data source |
 | [azurerm_user_assigned_identity.cert_manager_data](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/user_assigned_identity) | data source |
-| [github_actions_organization_registration_token.org](https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/actions_organization_registration_token) | data source |
 
 ## Inputs
 

--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -141,7 +141,7 @@ write_files:
       set -uo pipefail
 
       echo "[$(date)] Starting GitHub Actions runner setup script" | tee -a /var/log/cloud-init-output.log
-      
+
       # Variables from Terraform
       ORG_URL="https://github.com/${var_github_org}"
       GITHUB_TOKEN="${var_github_token}"
@@ -310,7 +310,7 @@ write_files:
 
       # Create runner directory and extract as ubuntu user
       sudo -u $RUNNER_USER mkdir -p "$INSTALL_DIR"
-      
+
       if [ -f "$TMPDIR/runner.tgz" ]; then
         echo "[$(date)] Extracting runner archive to $INSTALL_DIR" | tee -a /var/log/cloud-init-output.log
         sudo -u $RUNNER_USER tar -C "$INSTALL_DIR" -xzf "$TMPDIR/runner.tgz" || echo "[$(date)] Runner extraction failed" | tee -a /var/log/cloud-init-output.log
@@ -326,7 +326,7 @@ write_files:
       # Configure runner as ubuntu user
       if [ -x "$INSTALL_DIR/config.sh" ]; then
         secure_log "[$(date)] Configuring runner as $RUNNER_USER user"
-        
+
         if [ -z "$REG_TOKEN" ] || [ "$REG_TOKEN" = "null" ]; then
           secure_log "[$(date)] ERROR: Invalid registration token, cannot configure runner"
           exit 1
@@ -358,7 +358,7 @@ write_files:
 
       # Create systemd service to run as ubuntu user
       echo "[$(date)] Creating systemd service for GitHub Actions runner" | tee -a /var/log/cloud-init-output.log
-      
+
       cat > /etc/systemd/system/github-actions-runner.service <<EOF
 [Unit]
 Description=GitHub Actions Runner
@@ -433,7 +433,7 @@ EOF
         local timeout_duration=$1
         local description=$2
         shift 2
-        log_msg "Starting: $description (timeout: ${timeout_duration}s)"
+        log_msg "Starting: $description (timeout: $${timeout_duration}s)"
 
         if timeout "$timeout_duration" "$@"; then
           log_msg "Completed successfully: $description"
@@ -441,7 +441,7 @@ EOF
         else
           local exit_code=$?
           if [ $exit_code -eq 124 ]; then
-            log_msg "TIMEOUT after ${timeout_duration}s: $description"
+            log_msg "TIMEOUT after $${timeout_duration}s: $description"
           else
             log_msg "FAILED with exit code $exit_code: $description"
           fi
@@ -456,7 +456,7 @@ EOF
       vscode_found=false
       for i in {1..30}; do
         if command -v code >/dev/null 2>&1; then
-          log_msg "VS Code found after ${i} attempts ($(which code))"
+          log_msg "VS Code found after $${i} attempts ($(which code))"
           vscode_found=true
           break
         fi

--- a/cloudshell.tf
+++ b/cloudshell.tf
@@ -219,7 +219,7 @@ locals {
   ]
 
   # Determine if selected VM size has GPU
-  cloudshell_vm_size = "Standard_NC12s_v3" # Change this to configure VM size
+  cloudshell_vm_size = "Standard_D4s_v3" # Change this to configure VM size
   has_gpu            = var.cloudshell ? contains(local.gpu_enabled_vm_sizes, local.cloudshell_vm_size) : false
 }
 


### PR DESCRIPTION
## Summary

- **VM Size Change**: Downgrade from Standard_NC12s_v3 (GPU-enabled, expensive) to Standard_D4s_v3 (general-purpose, cost-effective)
- **Cost Impact**: Significant monthly cost reduction by removing unnecessary GPU resources
- **Performance**: Maintains sufficient resources (4 vCPU, 16GB RAM) for development workflows
- **Template Fix**: Fixed cloud-init template variable escaping issues for bash variables

## Technical Details

### VM Size Comparison
| Specification | Old (NC12s_v3) | New (D4s_v3) | Impact |
|---------------|----------------|--------------|---------|
| vCPUs | 12 | 4 | Reduced but adequate |
| RAM | 224 GB | 16 GB | Sufficient for development |
| GPU | 2x NVIDIA V100 | None | Cost reduction |
| Use Case | ML/AI workloads | General development | Better match |

### Template Variable Fixes
- Fixed `${timeout_duration}` → `$${timeout_duration}` in timeout logging
- Fixed `${i}` → `$${i}` in VS Code installation loop counter
- Ensures bash variables are properly escaped to prevent Terraform template interpretation

## Test Plan

- [x] `terraform fmt` passes
- [x] `terraform validate` passes 
- [x] All pre-commit hooks pass (trailing whitespace, terraform docs, etc.)
- [x] Template variable escaping resolves validation errors
- [ ] Deploy to test environment to verify VM boots correctly
- [ ] Confirm development tools work without GPU dependencies

## Benefits

1. **Cost Optimization**: Eliminates expensive GPU resources not currently utilized
2. **Right-sizing**: VM resources now match actual development workload requirements  
3. **Maintenance**: Simpler configuration without GPU driver dependencies
4. **Template Quality**: Improved cloud-init template with proper variable escaping

🤖 Generated with [Claude Code](https://claude.ai/code)