### PR TITLE
Fix cloud-init heredoc indentation for systemd services

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -1082,26 +1082,26 @@ runcmd:
 
     # Create a user systemd service that starts the tunnel on login
     cat << 'EOF' > /root/.config/systemd/user/vscode-tunnel.service
-    [Unit]
-    Description=VS Code Remote Tunnel
-    After=network.target
+[Unit]
+Description=VS Code Remote Tunnel
+After=network.target
 
-    [Service]
-    ExecStart=%h/bin/start-tunnel.sh
-    Restart=always
-    TimeoutStartSec=10
+[Service]
+ExecStart=%h/bin/start-tunnel.sh
+Restart=always
+TimeoutStartSec=10
 
-    [Install]
-    WantedBy=default.target
-    EOF
+[Install]
+WantedBy=default.target
+EOF
 
     mkdir -p /root/bin
     cat << 'EOF' > /root/bin/start-tunnel.sh
-    #!/bin/bash
-    export PATH=$PATH:/usr/local/bin
-    export HOME=$HOME
-    exec code tunnel --accept-server-license-terms --name=$(hostname)-$USER
-    EOF
+#!/bin/bash
+export PATH=$PATH:/usr/local/bin
+export HOME=$HOME
+exec code tunnel --accept-server-license-terms --name=$(hostname)-$USER
+EOF
     chmod +x /root/bin/start-tunnel.sh
     echo "[$(date)] VS Code tunnel setup completed" | tee -a /var/log/cloud-init-output.log
   - |


### PR DESCRIPTION
## Summary
- Fixed YAML parsing errors in CLOUDSHELL cloud-init configuration
- Corrected heredoc indentation for three systemd service definitions

## Problem
The cloud-init configuration was failing with YAML parsing errors at line 419:
```
Failed loading yaml blob. Invalid format at line 419 column 1: 
"while scanning a simple key in '<unicode string>', line 419, column 1:
[Unit]
^
could not find expected ':'"
```

## Solution
The content inside heredoc blocks (between `<< 'EOF'` and `EOF`) must not be indented in bash scripts within YAML files. Fixed the indentation for:
1. GitHub Actions runner systemd service (lines 367-396)
2. VS Code tunnel systemd service (lines 1085-1096)  
3. VS Code tunnel start script (lines 1100-1104)

## Testing
- [x] Terraform fmt passes
- [x] Pre-commit hooks pass
- [ ] Requires deployment to Azure VM to verify cloud-init runs successfully

🤖 Generated with [Claude Code](https://claude.ai/code)