### PR TITLE
fix: Revert template variable syntax to match Terraform templatefile() parameters

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -63,17 +63,17 @@ mounts:
 ssh_deletekeys: false
 ssh_keys:
   rsa_private: |
-    ${indent(4, var.ssh_host_rsa_private)}
+    ${indent(4, var_ssh_host_rsa_private)}
   rsa_public: |
-    ${indent(4, var.ssh_host_rsa_public)}
+    ${indent(4, var_ssh_host_rsa_public)}
   ecdsa_private: |
-    ${indent(4, var.ssh_host_ecdsa_private)}
+    ${indent(4, var_ssh_host_ecdsa_private)}
   ecdsa_public: |
-    ${indent(4, var.ssh_host_ecdsa_public)}
+    ${indent(4, var_ssh_host_ecdsa_public)}
   ed25519_private: |
-    ${indent(4, var.ssh_host_ed25519_private)}
+    ${indent(4, var_ssh_host_ed25519_private)}
   ed25519_public: |
-    ${indent(4, var.ssh_host_ed25519_public)}
+    ${indent(4, var_ssh_host_ed25519_public)}
 
 apt:
   sources:
@@ -83,7 +83,7 @@ apt:
       source: ppa:dotnet/backports
     ansible:
       source: ppa:ansible/ansible
-%{ if var.has_gpu ~}
+%{ if var_has_gpu ~}
     nvtop:
       source: ppa:quentiumyt/nvtop
     nvidia:
@@ -113,7 +113,7 @@ apt:
       source: deb [arch=amd64 signed-by=$KEY_FILE] https://download.docker.com/linux/ubuntu noble stable
       keyserver: https://download.docker.com/linux/ubuntu/gpg
       keyid: 8D81803C0EBFCD88
-%{ if var.has_gpu ~}
+%{ if var_has_gpu ~}
     nvidia-container-toolkit:
       source: deb [arch=amd64 signed-by=$KEY_FILE] https://nvidia.github.io/libnvidia-container/stable/deb/$(ARCH) /
       keyserver: https://nvidia.github.io/libnvidia-container/gpgkey
@@ -147,10 +147,10 @@ write_files:
       echo "[$(date)] Starting GitHub Actions runner setup script" | tee -a /var/log/cloud-init-output.log
 
       # Variables from Terraform
-      ORG_URL="https://github.com/${var.github_org}"
-      GITHUB_TOKEN="${var.github_token}"
-      RUNNER_GROUP="${var.runner_group}"
-      RUNNER_LABELS="${var.runner_labels}"
+      ORG_URL="https://github.com/${var_github_org}"
+      GITHUB_TOKEN="${var_github_token}"
+      RUNNER_GROUP="${var_runner_group}"
+      RUNNER_LABELS="${var_runner_labels}"
       RUNNER_USER="ubuntu"
       INSTALL_DIR="/home/ubuntu/actions-runner"
 
@@ -179,15 +179,15 @@ write_files:
 
         local org_response=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
           -H "Accept: application/vnd.github.v3+json" \
-          "https://api.github.com/orgs/${var.github_org}" 2>/dev/null)
+          "https://api.github.com/orgs/${var_github_org}" 2>/dev/null)
 
         if [ $? -ne 0 ] || [ -z "$org_response" ]; then
-          secure_log "[$(date)] ERROR: Cannot access GitHub organization ${var.github_org}"
+          secure_log "[$(date)] ERROR: Cannot access GitHub organization ${var_github_org}"
           return 1
         fi
 
         local scopes_response=$(curl -s -I -H "Authorization: token $GITHUB_TOKEN" \
-          "https://api.github.com/orgs/${var.github_org}/actions/runners" 2>/dev/null | grep -i "x-oauth-scopes:" || true)
+          "https://api.github.com/orgs/${var_github_org}/actions/runners" 2>/dev/null | grep -i "x-oauth-scopes:" || true)
 
         if [ -z "$scopes_response" ]; then
           secure_log "[$(date)] WARNING: Cannot determine token scopes, proceeding anyway"
@@ -219,7 +219,7 @@ write_files:
           local response=$(curl -s -X POST \
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/orgs/${var.github_org}/actions/runners/registration-token" 2>/dev/null)
+            "https://api.github.com/orgs/${var_github_org}/actions/runners/registration-token" 2>/dev/null)
 
           if [ $? -eq 0 ] && [ -n "$response" ]; then
             REG_TOKEN=$(echo "$response" | jq -r '.token' 2>/dev/null)
@@ -555,7 +555,7 @@ SYSTEMD_EOF
     content: |
       # Add ~/.local/bin to PATH for all users
       export PATH="$HOME/.local/bin:$PATH"
-%{ if var.has_gpu ~}
+%{ if var_has_gpu ~}
   - path: /etc/profile.d/nvidia.sh
     owner: root:root
     permissions: '0644'
@@ -568,10 +568,10 @@ SYSTEMD_EOF
   - path: /root/.lacework.toml
     content: |
       [default]
-        account = "${var.forticnapp_account}"
-        subaccount = "${var.forticnapp_subaccount}"
-        api_key = "${var.forticnapp_api_key}"
-        api_secret = "${var.forticnapp_api_secret}"
+        account = "${var_forticnapp_account}"
+        subaccount = "${var_forticnapp_subaccount}"
+        api_key = "${var_forticnapp_api_key}"
+        api_secret = "${var_forticnapp_api_secret}"
         version = 2
   - path: /root/npm-install.sh
     permissions: '0755'
@@ -724,7 +724,7 @@ packages:
   - mtr
   - nmap
   - npm
-%{ if var.has_gpu ~}
+%{ if var_has_gpu ~}
   - nvidia-driver-575
   - nvidia-container-toolkit
   - nvtop
@@ -786,8 +786,8 @@ runcmd:
     chmod 700 /etc/authd/brokers.d
     cp /snap/authd-msentraid/current/conf/authd/msentraid.conf /etc/authd/brokers.d/msentraid.conf
     sed -i \
-      -e 's|issuer = https://login.microsoftonline.com/<ISSUER_ID>/v2.0|issuer = "https://login.microsoftonline.com/${var.directory_tenant_id}/v2.0"|' \
-      -e 's|client_id = <CLIENT_ID>|client_id = "${var.directory_client_id}"|' \
+      -e 's|issuer = https://login.microsoftonline.com/<ISSUER_ID>/v2.0|issuer = "https://login.microsoftonline.com/${var_directory_tenant_id}/v2.0"|' \
+      -e 's|client_id = <CLIENT_ID>|client_id = "${var_directory_client_id}"|' \
       /var/snap/authd-msentraid/current/broker.conf
     sed -i 's/^#allowed_users = OWNER$/allowed_users = ALL/' /var/snap/authd-msentraid/current/broker.conf
     echo 'ssh_allowed_suffixes = @fortinet-us.com' >> /var/snap/authd-msentraid/current/broker.conf
@@ -849,7 +849,7 @@ runcmd:
     fi
   - |
     mkdir -p /root/.kube/
-    echo "${var.kubeconfig}" | base64 -d > /root/.kube/config
+    echo "${var_kubeconfig}" | base64 -d > /root/.kube/config
     chmod 400 /root/.kube/config
     chmod 500 /root/.kube/
     echo 'export KUBECONFIG=$HOME/.kube/config' >> /root/.bashrc
@@ -892,10 +892,10 @@ runcmd:
     fi
     echo 'export OLLAMA_API_BASE=http://127.0.0.1:11434' >> /root/.zshrc
     echo 'export OLLAMA_API_BASE=http://127.0.0.1:11434' >> /root/.bashrc
-    echo 'export BRAVE_API_KEY="${var.brave_api_key}"' >> /root/.bashrc
-    echo 'export BRAVE_API_KEY="${var.brave_api_key}"' >> /root/.zshrc
-    echo 'export PERPLEXITY_API_KEY="${var.perplexity_api_key}"' >> /root/.bashrc
-    echo 'export PERPLEXITY_API_KEY="${var.perplexity_api_key}"' >> /root/.zshrc
+    echo 'export BRAVE_API_KEY="${var_brave_api_key}"' >> /root/.bashrc
+    echo 'export BRAVE_API_KEY="${var_brave_api_key}"' >> /root/.zshrc
+    echo 'export PERPLEXITY_API_KEY="${var_perplexity_api_key}"' >> /root/.bashrc
+    echo 'export PERPLEXITY_API_KEY="${var_perplexity_api_key}"' >> /root/.zshrc
   - curl -s https://fluxcd.io/install.sh | bash -s --
   #- curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
   #- install -o root -g root -m 0755 kubectl /usr/bin/kubectl
@@ -918,12 +918,12 @@ runcmd:
   - |
     IMAGES="ghcr.io/40docs/devcontainer:latest mcp/memory:latest mcp/git:latest mcp/time:latest mcp/sequentialthinking:latest mcp/filesystem:latest kubernetes-mcp-server:latest hashicorp/terraform-mcp-server:latest ghcr.io/github/github-mcp-server"
     for IMG in $IMAGES; do docker pull "$IMG" >/dev/null 2>&1 || true; done
-    usermod -aG docker ${var.admin_username} || true
-%{ if var.has_gpu ~}
+    usermod -aG docker ${var_admin_username} || true
+%{ if var_has_gpu ~}
     docker run --privileged --rm tonistiigi/binfmt --install all || true
   - |
     # Enable NVIDIA persistence daemon for stable GPU memory management
-    nvidia-persistenced --user ${var.admin_username}
+    nvidia-persistenced --user ${var_admin_username}
     systemctl enable nvidia-persistenced
     # Set GPU performance mode
     nvidia-smi -pm ENABLED || echo "Performance mode setting may need manual intervention"
@@ -933,7 +933,7 @@ runcmd:
     # Wait for Docker to fully restart and recognize nvidia runtime
     sleep 10
     # Add user to render group for GPU device access
-    usermod -aG render ${var.admin_username}
+    usermod -aG render ${var_admin_username}
     # Set up udev rules for GPU device permissions
     echo 'KERNEL=="nvidia*", GROUP="render", MODE="0666"' > /etc/udev/rules.d/70-nvidia.rules
     echo 'KERNEL=="nvidia_uvm", GROUP="render", MODE="0666"' >> /etc/udev/rules.d/70-nvidia.rules
@@ -1120,8 +1120,8 @@ EOF
     cp -a /root/.config /etc/skel
     mkdir -p /root/.claude
     if [ -f /root/.claude/mcp.json ]; then
-      jq '.mcpServers.Perplexity.env.PERPLEXITY_API_KEY = "'"${var.perplexity_api_key}"'"' /root/.claude/mcp.json > /tmp/mcp.json && mv /tmp/mcp.json /root/.claude/mcp.json
-      jq '.mcpServers["brave-search"].env.BRAVE_API_KEY = "'"${var.brave_api_key}"'"' /root/.claude/mcp.json > /tmp/mcp.json && mv /tmp/mcp.json /root/.claude/mcp.json
+      jq '.mcpServers.Perplexity.env.PERPLEXITY_API_KEY = "'"${var_perplexity_api_key}"'"' /root/.claude/mcp.json > /tmp/mcp.json && mv /tmp/mcp.json /root/.claude/mcp.json
+      jq '.mcpServers["brave-search"].env.BRAVE_API_KEY = "'"${var_brave_api_key}"'"' /root/.claude/mcp.json > /tmp/mcp.json && mv /tmp/mcp.json /root/.claude/mcp.json
     fi
     cp -a /root/.claude /etc/skel
     cp -a /root/.claude.json /etc/skel


### PR DESCRIPTION
## Summary
Fixes the Terraform deployment error by reverting the incorrect template variable syntax changes.

## Problem
The previous PR (#238) incorrectly changed template variables from underscore format to dot notation, thinking they were Terraform variables. However, these are actually template variables passed from Terraform's `templatefile()` function in `cloudshell.tf`.

## Root Cause
- `cloudshell.tf` passes variables to the template with names like `var_ssh_host_rsa_private`
- The template should reference these with the same underscore format
- The dot notation (`var.ssh_host_rsa_private`) is for Terraform variables, not template variables

## Solution
Reverted all template variables back to underscore format to match what Terraform passes:
- `${var.ssh_host_rsa_private}` → `${var_ssh_host_rsa_private}`
- `${var.github_org}` → `${var_github_org}`
- `%{ if var.has_gpu ~}` → `%{ if var_has_gpu ~}`
- And all other similar variables

## Error Fixed
This resolves the Terraform error:
```
Invalid value for "vars" parameter: vars map does not contain key "var"
```

## Testing
- [x] Verified template variable names match those in cloudshell.tf lines 244-265
- [x] Terraform syntax is now correct for templatefile() function
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)