### PR TITLE
fix: Escape systemd service definition in cloud-init YAML parsing error

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -363,37 +363,41 @@ write_files:
       # Create systemd service to run as ubuntu user
       echo "[$(date)] Creating systemd service for GitHub Actions runner" | tee -a /var/log/cloud-init-output.log
 
-      cat > /etc/systemd/system/github-actions-runner.service << SYSTEMD_EOF
-[Unit]
-Description=GitHub Actions Runner
-After=network.target
+      cat > /etc/systemd/system/github-actions-runner.service << 'SYSTEMD_EOF'
+      [Unit]
+      Description=GitHub Actions Runner
+      After=network.target
 
-[Service]
-Type=simple
-User=$RUNNER_USER
-Group=$RUNNER_USER
-WorkingDirectory=$INSTALL_DIR
-ExecStart=$INSTALL_DIR/run.sh
-Restart=always
-RestartSec=10
-KillMode=process
-KillSignal=SIGTERM
-TimeoutStopSec=5
+      [Service]
+      Type=simple
+      User='$RUNNER_USER'
+      Group='$RUNNER_USER'
+      WorkingDirectory='$INSTALL_DIR'
+      ExecStart='$INSTALL_DIR'/run.sh
+      Restart=always
+      RestartSec=10
+      KillMode=process
+      KillSignal=SIGTERM
+      TimeoutStopSec=5
 
-# Environment
-Environment="RUNNER_ALLOW_RUNASROOT=0"
+      # Environment
+      Environment="RUNNER_ALLOW_RUNASROOT=0"
 
-# Security settings
-PrivateTmp=false
-NoNewPrivileges=true
-ProtectSystem=strict
-ProtectHome=read-only
-ReadWritePaths=$INSTALL_DIR
-ReadWritePaths=/home/$RUNNER_USER
+      # Security settings
+      PrivateTmp=false
+      NoNewPrivileges=true
+      ProtectSystem=strict
+      ProtectHome=read-only
+      ReadWritePaths='$INSTALL_DIR'
+      ReadWritePaths=/home/'$RUNNER_USER'
 
-[Install]
-WantedBy=multi-user.target
-SYSTEMD_EOF
+      [Install]
+      WantedBy=multi-user.target
+      SYSTEMD_EOF
+
+      # Now substitute the variables in the service file
+      sed -i "s|'\$RUNNER_USER'|$RUNNER_USER|g" /etc/systemd/system/github-actions-runner.service
+      sed -i "s|'\$INSTALL_DIR'|$INSTALL_DIR|g" /etc/systemd/system/github-actions-runner.service
 
       # Reload systemd and start the service
       echo "[$(date)] Starting GitHub Actions runner service" | tee -a /var/log/cloud-init-output.log


### PR DESCRIPTION
## Summary
- Fixed YAML parsing error in CLOUDSHELL.conf that was preventing cloud-init from completing
- Properly escaped systemd service definition in the GitHub Actions runner setup script
- Used quoted heredoc and sed substitution to handle variable expansion correctly

## Problem
The cloud-init logs showed YAML parsing errors at line 419:
```
Failed loading yaml blob. Invalid format at line 419 column 1: "while scanning a simple key
  in "<unicode string>", line 419, column 1:
    [Unit]
    ^
could not find expected ':'
```

## Solution
The systemd service definition within the actions-runner-setup.sh script was not properly escaped, causing the YAML parser to interpret `[Unit]`, `[Service]`, and `[Install]` sections as YAML syntax instead of plain text content.

Fixed by:
1. Using a quoted heredoc delimiter (`'SYSTEMD_EOF'`) to prevent premature variable expansion
2. Adding placeholder variables with single quotes in the service definition
3. Using sed commands to substitute the actual variable values after writing the file
4. Properly indenting the embedded systemd content

## Test Plan
- [x] Terraform fmt passes
- [x] Terraform validate passes
- [x] No YAML parsing errors in configuration
- [ ] Deploy to test environment and verify cloud-init completes successfully
- [ ] Verify GitHub Actions runner service starts correctly

🤖 Generated with [Claude Code](https://claude.ai/code)