### PR TITLE
fix: Escape VS Code tunnel systemd service definition YAML parsing error

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -1085,27 +1085,27 @@ runcmd:
     mkdir -p /root/.config/systemd/user
 
     # Create a user systemd service that starts the tunnel on login
-    cat << 'EOF' > /root/.config/systemd/user/vscode-tunnel.service
-[Unit]
-Description=VS Code Remote Tunnel
-After=network.target
+    cat << 'VSCODE_EOF' > /root/.config/systemd/user/vscode-tunnel.service
+    [Unit]
+    Description=VS Code Remote Tunnel
+    After=network.target
 
-[Service]
-ExecStart=%h/bin/start-tunnel.sh
-Restart=always
-TimeoutStartSec=10
+    [Service]
+    ExecStart=%h/bin/start-tunnel.sh
+    Restart=always
+    TimeoutStartSec=10
 
-[Install]
-WantedBy=default.target
-EOF
+    [Install]
+    WantedBy=default.target
+    VSCODE_EOF
 
     mkdir -p /root/bin
-    cat << 'EOF' > /root/bin/start-tunnel.sh
-#!/bin/bash
-export PATH=$PATH:/usr/local/bin
-export HOME=$HOME
-exec code tunnel --accept-server-license-terms --name=$(hostname)-$USER
-EOF
+    cat << 'SCRIPT_EOF' > /root/bin/start-tunnel.sh
+    #!/bin/bash
+    export PATH=$PATH:/usr/local/bin
+    export HOME=$HOME
+    exec code tunnel --accept-server-license-terms --name=$(hostname)-$USER
+    SCRIPT_EOF
     chmod +x /root/bin/start-tunnel.sh
     echo "[$(date)] VS Code tunnel setup completed" | tee -a /var/log/cloud-init-output.log
   - |


### PR DESCRIPTION
## Summary
- Fixed second YAML parsing error in CLOUDSHELL.conf at line 1095
- Properly escaped VS Code tunnel systemd service definition
- Used unique heredoc delimiters to prevent YAML syntax interpretation

## Problem
The cloud-init logs showed another YAML parsing error at line 1095:
```
Failed loading yaml blob. Invalid format at line 1095 column 1: "while scanning a simple key
  in "<unicode string>", line 1095, column 1:
    [Unit]
    ^
could not find expected ':'
  in "<unicode string>", line 1096, column 1:
    Description=VS Code Remote Tunnel
    ^"
```

## Solution
The VS Code tunnel systemd service definition was using a generic `EOF` delimiter, causing the same YAML parsing issue as the previous GitHub Actions runner service. The `[Unit]`, `[Service]`, and `[Install]` sections were being interpreted as YAML syntax.

Fixed by:
1. Using unique quoted heredoc delimiters (`'VSCODE_EOF'`, `'SCRIPT_EOF'`)
2. Properly indenting the systemd content within the heredocs
3. Ensuring the unit file content is treated as literal text, not YAML

## Test Plan
- [x] Terraform fmt passes
- [x] Terraform validate passes  
- [x] No YAML parsing errors in configuration
- [x] All systemd service definitions properly escaped
- [ ] Deploy to test environment and verify cloud-init completes successfully
- [ ] Verify VS Code tunnel service starts correctly

This resolves the remaining YAML parsing error preventing CLOUDSHELL VM initialization.

🤖 Generated with [Claude Code](https://claude.ai/code)