### PR TITLE
Fix GitHub Actions runner installation in cloud-init

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -163,7 +163,11 @@ write_files:
       # Install runner
       echo "[$(date)] Installing GitHub Actions runner..." | tee -a /var/log/cloud-init-output.log
       RUNNER_DIR="/home/ubuntu/actions-runner"
+      
+      # Clean up any existing runner directory and create with proper ownership
+      rm -rf "$RUNNER_DIR"
       mkdir -p "$RUNNER_DIR"
+      chown -R ubuntu:ubuntu "$RUNNER_DIR"
       cd "$RUNNER_DIR"
 
       # Download latest runner
@@ -172,6 +176,7 @@ write_files:
       
       echo "[$(date)] Downloading runner version $${RUNNER_VERSION}..." | tee -a /var/log/cloud-init-output.log
       if curl -o actions-runner.tar.gz -L "$RUNNER_URL"; then
+        echo "[$(date)] Extracting runner archive..." | tee -a /var/log/cloud-init-output.log
         sudo -u ubuntu tar xzf ./actions-runner.tar.gz
         rm -f actions-runner.tar.gz
         
@@ -189,28 +194,48 @@ write_files:
           jq -r '.token')
         
         if [ -n "$REG_TOKEN" ] && [ "$REG_TOKEN" != "null" ]; then
+          echo "[$(date)] Registration token obtained successfully" | tee -a /var/log/cloud-init-output.log
           echo "[$(date)] Configuring runner..." | tee -a /var/log/cloud-init-output.log
-          # Configure runner
-          sudo -u ubuntu ./config.sh \
+          
+          # Configure runner with proper error handling
+          if sudo -u ubuntu ./config.sh \
             --url "$ORG_URL" \
             --token "$REG_TOKEN" \
             --name "$RUNNER_NAME" \
             --work "_work" \
             --unattended \
-            --replace || true
-          
-          # Install as service
-          echo "[$(date)] Installing runner as service..." | tee -a /var/log/cloud-init-output.log
-          ./svc.sh install ubuntu
-          
-          # Start service
-          echo "[$(date)] Starting runner service..." | tee -a /var/log/cloud-init-output.log
-          systemctl start "actions.runner.${var_github_org}.$RUNNER_NAME"
-          systemctl enable "actions.runner.${var_github_org}.$RUNNER_NAME"
-          
-          echo "[$(date)] GitHub Actions runner setup completed successfully" | tee -a /var/log/cloud-init-output.log
+            --replace \
+            --runnergroup "$${RUNNER_GROUP:-Default}" \
+            --labels "$${RUNNER_LABELS:-self-hosted,cloudshell,azure}"; then
+            
+            echo "[$(date)] Runner configured successfully" | tee -a /var/log/cloud-init-output.log
+            
+            # Install as service
+            echo "[$(date)] Installing runner as service..." | tee -a /var/log/cloud-init-output.log
+            if ./svc.sh install ubuntu; then
+              echo "[$(date)] Runner service installed successfully" | tee -a /var/log/cloud-init-output.log
+              
+              # Start service
+              echo "[$(date)] Starting runner service..." | tee -a /var/log/cloud-init-output.log
+              if systemctl start "actions.runner.${var_github_org}.$RUNNER_NAME" && \
+                 systemctl enable "actions.runner.${var_github_org}.$RUNNER_NAME"; then
+                echo "[$(date)] GitHub Actions runner setup completed successfully" | tee -a /var/log/cloud-init-output.log
+                systemctl status "actions.runner.${var_github_org}.$RUNNER_NAME" --no-pager | tee -a /var/log/cloud-init-output.log
+              else
+                echo "[$(date)] ERROR: Failed to start runner service" | tee -a /var/log/cloud-init-output.log
+                exit 1
+              fi
+            else
+              echo "[$(date)] ERROR: Failed to install runner service" | tee -a /var/log/cloud-init-output.log
+              exit 1
+            fi
+          else
+            echo "[$(date)] ERROR: Failed to configure runner" | tee -a /var/log/cloud-init-output.log
+            exit 1
+          fi
         else
-          echo "[$(date)] ERROR: Failed to get registration token" | tee -a /var/log/cloud-init-output.log
+          echo "[$(date)] ERROR: Failed to get registration token - GitHub token may be expired or invalid" | tee -a /var/log/cloud-init-output.log
+          echo "[$(date)] Token response: $REG_TOKEN" | tee -a /var/log/cloud-init-output.log
           exit 1
         fi
       else


### PR DESCRIPTION
## Summary
- Fixed permission issues that prevented runner from installing correctly
- Runner directory is now properly owned by ubuntu user before extraction
- Added comprehensive error handling and logging

## Problem
The GitHub Actions runner was failing to install during cloud-init because:
1. The runner directory was created as root (mkdir was run as root)
2. The tar extraction was run as ubuntu user (sudo -u ubuntu)
3. This permission mismatch caused extraction to fail with 'Permission denied' errors

## Solution
- Clean up any existing runner directory before installation
- Create the directory and immediately set ownership to ubuntu:ubuntu
- Add detailed logging at each step for better troubleshooting
- Include proper error handling with descriptive messages
- Add runner group and labels configuration with sensible defaults

## Testing
- [x] Terraform fmt passes
- [x] Terraform validate passes
- [x] Manually tested the fix on the CLOUDSHELL VM
- [x] Runner successfully installs and connects to GitHub

## Related Issues
Fixes the runner installation issue discovered during CLOUDSHELL VM deployment