### PR TITLE
Fix runner labels for test workflow

### DIFF
--- a/.github/workflows/test-cloudshell-runner.yml
+++ b/.github/workflows/test-cloudshell-runner.yml
@@ -20,10 +20,7 @@ permissions:
 jobs:
   test-runner:
     name: "Test CLOUDSHELL Self-Hosted Runner"
-    runs-on: 
-      - self-hosted
-      - cloudshell
-      - azure
+    runs-on: self-hosted
     timeout-minutes: 10
 
     steps:


### PR DESCRIPTION
## Problem
The test workflow was stuck in 'queued' state because it was looking for a runner with specific labels `[self-hosted, cloudshell, azure]` but the runner was only configured with default labels.

## Solution
- Simplify `runs-on` to use only `self-hosted` label
- This allows any self-hosted runner to pick up the job
- The CLOUDSHELL runner will now be able to execute the test workflow

## Testing
Once merged, the workflow should immediately start running on the CLOUDSHELL runner instead of staying queued.

🎯 **Expected Result**: Test workflow executes successfully on CLOUDSHELL runner