### PR TITLE
Try CLOUDSHELL uppercase label for runner

### DIFF
--- a/.github/workflows/test-cloudshell-runner.yml
+++ b/.github/workflows/test-cloudshell-runner.yml
@@ -20,7 +20,9 @@ permissions:
 jobs:
   test-runner:
     name: "Test CLOUDSHELL Self-Hosted Runner"
-    runs-on: self-hosted
+    runs-on: 
+      - self-hosted
+      - CLOUDSHELL
     timeout-minutes: 10
 
     steps:


### PR DESCRIPTION
Testing if runner label needs to be uppercase CLOUDSHELL to match hostname