### PR TITLE
Target CLOUDSHELL runner specifically

### DIFF
--- a/.github/workflows/test-cloudshell-runner.yml
+++ b/.github/workflows/test-cloudshell-runner.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   test-runner:
     name: "Test CLOUDSHELL Self-Hosted Runner"
-    runs-on: self-hosted
+    runs-on: CLOUDSHELL
     timeout-minutes: 10
 
     steps:


### PR DESCRIPTION
## Change Summary
Changed `runs-on` from `self-hosted` to `CLOUDSHELL` to target the runner by its specific hostname.

## Rationale
- Previous attempts with `self-hosted` label resulted in queued jobs
- Using the specific runner name/hostname may resolve the matching issue
- The runner service name is `actions.runner.40docs.CLOUDSHELL`, indicating it should respond to `CLOUDSHELL` label

## Expected Outcome
- Workflow should now successfully execute on the CLOUDSHELL runner
- Jobs should transition from 'queued' to 'running' status
- Full system capabilities test will complete on the target VM

## Testing
This change will be automatically tested when the workflow triggers on merge, providing immediate validation of the runner targeting fix.

🎯 **Goal**: Achieve successful workflow execution on the CLOUDSHELL self-hosted runner