### PR TITLE
fix: Remove bash parameter expansion syntax from Terraform template

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -244,9 +244,15 @@ write_files:
           # Set environment variables with proper defaults
           export ORG_URL="https://github.com/${var_github_org}"
           export GITHUB_TOKEN="${var_github_token}"
-          export RUNNER_GROUP="${var_runner_group:-Default}"
-          # CRITICAL FIX: Ensure labels are always set with working defaults
-          export RUNNER_LABELS="${var_runner_labels:-self-hosted,CLOUDSHELL,cloudshell,azure}"
+          export RUNNER_GROUP="${var_runner_group}"
+          # CRITICAL FIX: Ensure labels always include CLOUDSHELL for job targeting
+          # Check if CLOUDSHELL label is already included, if not add it
+          LABELS_BASE="${var_runner_labels}"
+          if [[ "$$LABELS_BASE" != *"CLOUDSHELL"* ]]; then
+            export RUNNER_LABELS="$$LABELS_BASE,CLOUDSHELL,cloudshell"
+          else
+            export RUNNER_LABELS="$$LABELS_BASE"
+          fi
           export RUNNER_NAME="$$(hostname)"
 
           # Validate inputs


### PR DESCRIPTION
- Fix templatefile interpolation error in cloud-init/CLOUDSHELL.conf
- Remove colon syntax that conflicts with Terraform templatefile
- Add logic to ensure CLOUDSHELL labels are included for job targeting
- Maintain backward compatibility with existing variable defaults