### PR TITLE
Fix GitHub Actions runner cloud-init syntax errors

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -151,47 +151,47 @@ write_files:
       RETRY_DELAY=10
 
       log_message() {
-          echo "[$(date '+%Y-%m-%d %H:%M:%S')] $$1" | tee -a "$${LOGFILE}"
+          echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" | tee -a "$${LOGFILE}"
       }
 
       retry_command() {
-          local cmd="$$1"
-          local description="$$2"
+          local cmd="$1"
+          local description="$2"
           local retries=0
           
-          while [ $$retries -lt $$MAX_RETRIES ]; do
-              log_message "Attempting: $$description (attempt $$((retries + 1))/$$MAX_RETRIES)"
-              if eval "$$cmd"; then
-                  log_message "SUCCESS: $$description"
+          while [ $retries -lt $MAX_RETRIES ]; do
+              log_message "Attempting: $description (attempt $((retries + 1))/$MAX_RETRIES)"
+              if eval "$cmd"; then
+                  log_message "SUCCESS: $description"
                   return 0
               else
-                  retries=$$((retries + 1))
-                  if [ $$retries -lt $$MAX_RETRIES ]; then
-                      log_message "RETRY: $$description failed, retrying in $${RETRY_DELAY}s..."
-                      sleep $$RETRY_DELAY
+                  retries=$((retries + 1))
+                  if [ $retries -lt $MAX_RETRIES ]; then
+                      log_message "RETRY: $description failed, retrying in $${RETRY_DELAY}s..."
+                      sleep $RETRY_DELAY
                   fi
               fi
           done
           
-          log_message "ERROR: $$description failed after $$MAX_RETRIES attempts"
+          log_message "ERROR: $description failed after $MAX_RETRIES attempts"
           return 1
       }
 
       validate_token() {
-          local token="$$1"
+          local token="$1"
           log_message "Validating GitHub token..."
           
           local user_response
-          user_response=$$(curl -s -H "Authorization: token $$token" "https://api.github.com/user")
+          user_response=$(curl -s -H "Authorization: token $token" "https://api.github.com/user")
           
-          if echo "$$user_response" | jq -e '.login' >/dev/null 2>&1; then
+          if echo "$user_response" | jq -e '.login' >/dev/null 2>&1; then
               local username
-              username=$$(echo "$$user_response" | jq -r '.login')
-              log_message "Token validated for user: $$username"
+              username=$(echo "$user_response" | jq -r '.login')
+              log_message "Token validated for user: $username"
               return 0
           else
               log_message "ERROR: Token validation failed"
-              log_message "Response: $$user_response"
+              log_message "Response: $user_response"
               return 1
           fi
       }
@@ -201,8 +201,8 @@ write_files:
           
           # Check if required commands are available
           for cmd in curl jq tar; do
-              if ! command -v $$cmd >/dev/null 2>&1; then
-                  log_message "ERROR: Required command $$cmd not found"
+              if ! command -v $cmd >/dev/null 2>&1; then
+                  log_message "ERROR: Required command $cmd not found"
                   return 1
               fi
           done
@@ -216,17 +216,17 @@ write_files:
       }
 
       cleanup_existing_runner() {
-          local runner_dir="$$1"
-          local service_name="$$2"
+          local runner_dir="$1"
+          local service_name="$2"
           
-          if [ -d "$$runner_dir" ]; then
+          if [ -d "$runner_dir" ]; then
               log_message "Removing existing runner directory..."
               
               # Stop service if running
-              if systemctl is-active --quiet "$$service_name"; then
+              if systemctl is-active --quiet "$service_name"; then
                   log_message "Stopping existing runner service..."
-                  systemctl stop "$$service_name" 2>/dev/null || true
-                  systemctl disable "$$service_name" 2>/dev/null || true
+                  systemctl stop "$service_name" 2>/dev/null || true
+                  systemctl disable "$service_name" 2>/dev/null || true
               fi
               
               # Remove service file
@@ -234,7 +234,7 @@ write_files:
               systemctl daemon-reload
               
               # Remove runner directory
-              rm -rf "$$runner_dir"
+              rm -rf "$runner_dir"
           fi
       }
 
@@ -248,15 +248,15 @@ write_files:
           # CRITICAL FIX: Ensure labels always include CLOUDSHELL for job targeting
           # Check if CLOUDSHELL label is already included, if not add it
           LABELS_BASE="${var_runner_labels}"
-          if [[ "$$LABELS_BASE" != *"CLOUDSHELL"* ]]; then
-            export RUNNER_LABELS="$$LABELS_BASE,CLOUDSHELL,cloudshell"
+          if [[ "$LABELS_BASE" != *"CLOUDSHELL"* ]]; then
+            export RUNNER_LABELS="$LABELS_BASE,CLOUDSHELL,cloudshell"
           else
-            export RUNNER_LABELS="$$LABELS_BASE"
+            export RUNNER_LABELS="$LABELS_BASE"
           fi
-          export RUNNER_NAME="$$(hostname)"
+          export RUNNER_NAME="$(hostname)"
 
           # Validate inputs
-          if [ -z "$$GITHUB_TOKEN" ]; then
+          if [ -z "$GITHUB_TOKEN" ]; then
               log_message "ERROR: GitHub token is empty"
               exit 1
           fi
@@ -268,7 +268,7 @@ write_files:
           fi
 
           # Validate GitHub token
-          if ! validate_token "$$GITHUB_TOKEN"; then
+          if ! validate_token "$GITHUB_TOKEN"; then
               log_message "ERROR: GitHub token validation failed"
               exit 1
           fi
@@ -293,19 +293,19 @@ write_files:
           # Install runner
           log_message "Installing GitHub Actions runner..."
           RUNNER_DIR="/home/ubuntu/actions-runner"
-          SERVICE_NAME="actions.runner.${var_github_org}.$$RUNNER_NAME"
+          SERVICE_NAME="actions.runner.${var_github_org}.$RUNNER_NAME"
           
           # Clean up existing installation
-          cleanup_existing_runner "$$RUNNER_DIR" "$$SERVICE_NAME"
+          cleanup_existing_runner "$RUNNER_DIR" "$SERVICE_NAME"
           
-          mkdir -p "$$RUNNER_DIR"
-          chown -R ubuntu:ubuntu "$$RUNNER_DIR"
-          cd "$$RUNNER_DIR"
+          mkdir -p "$RUNNER_DIR"
+          chown -R ubuntu:ubuntu "$RUNNER_DIR"
+          cd "$RUNNER_DIR"
 
           # Download runner with retry logic
           RUNNER_URL="https://github.com/actions/runner/releases/download/v$${RUNNER_VERSION}/actions-runner-linux-x64-$${RUNNER_VERSION}.tar.gz"
           
-          if ! retry_command "curl -o actions-runner.tar.gz -L '$$RUNNER_URL'" "Download GitHub Actions runner"; then
+          if ! retry_command "curl -o actions-runner.tar.gz -L '$RUNNER_URL'" "Download GitHub Actions runner"; then
               log_message "ERROR: Failed to download runner after retries"
               exit 1
           fi
@@ -332,16 +332,16 @@ write_files:
           # Get registration token with retry
           log_message "Getting registration token..."
           
-          get_token_cmd="curl -s -X POST -H 'Accept: application/vnd.github.v3+json' -H 'Authorization: token $$GITHUB_TOKEN' 'https://api.github.com/orgs/${var_github_org}/actions/runners/registration-token'"
+          get_token_cmd="curl -s -X POST -H 'Accept: application/vnd.github.v3+json' -H 'Authorization: token $GITHUB_TOKEN' 'https://api.github.com/orgs/${var_github_org}/actions/runners/registration-token'"
           
           REG_TOKEN_RESPONSE=""
-          if retry_command "REG_TOKEN_RESPONSE=\$$($$get_token_cmd)" "Get registration token"; then
-              REG_TOKEN=$$(echo "$$REG_TOKEN_RESPONSE" | jq -r '.token')
-              if [ -n "$$REG_TOKEN" ] && [ "$$REG_TOKEN" != "null" ]; then
+          if retry_command "REG_TOKEN_RESPONSE=\$($get_token_cmd)" "Get registration token"; then
+              REG_TOKEN=$(echo "$REG_TOKEN_RESPONSE" | jq -r '.token')
+              if [ -n "$REG_TOKEN" ] && [ "$REG_TOKEN" != "null" ]; then
                   log_message "Registration token obtained successfully"
               else
-                  log_message "ERROR: Invalid registration token received: $$REG_TOKEN"
-                  log_message "Full response: $$REG_TOKEN_RESPONSE"
+                  log_message "ERROR: Invalid registration token received: $REG_TOKEN"
+                  log_message "Full response: $REG_TOKEN_RESPONSE"
                   exit 1
               fi
           else
@@ -350,17 +350,17 @@ write_files:
           fi
           
           # Configure runner with enhanced error handling
-          log_message "Configuring runner with labels: $$RUNNER_LABELS"
+          log_message "Configuring runner with labels: $RUNNER_LABELS"
           
           if sudo -u ubuntu ./config.sh \
-              --url "$$ORG_URL" \
-              --token "$$REG_TOKEN" \
-              --name "$$RUNNER_NAME" \
+              --url "$ORG_URL" \
+              --token "$REG_TOKEN" \
+              --name "$RUNNER_NAME" \
               --work "_work" \
               --unattended \
               --replace \
-              --runnergroup "$$RUNNER_GROUP" \
-              --labels "$$RUNNER_LABELS"; then
+              --runnergroup "$RUNNER_GROUP" \
+              --labels "$RUNNER_LABELS"; then
               log_message "Runner configured successfully"
           else
               log_message "ERROR: Failed to configure runner"
@@ -375,27 +375,27 @@ write_files:
               # Reload systemd and start service
               systemctl daemon-reload
               
-              log_message "Starting runner service: $$SERVICE_NAME"
-              if systemctl start "$$SERVICE_NAME" && systemctl enable "$$SERVICE_NAME"; then
+              log_message "Starting runner service: $SERVICE_NAME"
+              if systemctl start "$SERVICE_NAME" && systemctl enable "$SERVICE_NAME"; then
                   log_message "GitHub Actions runner setup completed successfully"
                   
                   # Verify service is running with timeout
                   sleep 10
-                  if systemctl is-active --quiet "$$SERVICE_NAME"; then
+                  if systemctl is-active --quiet "$SERVICE_NAME"; then
                       log_message "✅ Service verification: Runner is active and running"
-                      systemctl status "$$SERVICE_NAME" --no-pager | tee -a "$$LOGFILE"
+                      systemctl status "$SERVICE_NAME" --no-pager | tee -a "$LOGFILE"
                       
                       # Additional health check
                       if ps aux | grep -v grep | grep "Runner.Listener" >/dev/null; then
                           log_message "✅ Process verification: Runner listener is running"
-                          log_message "✅ Runner labels configured: $$RUNNER_LABELS"
+                          log_message "✅ Runner labels configured: $RUNNER_LABELS"
                           log_message "✅ Runner ready to accept jobs for organization: ${var_github_org}"
                       else
                           log_message "⚠️  WARNING: Runner listener process not detected"
                       fi
                   else
                       log_message "❌ WARNING: Service may not be running properly"
-                      systemctl status "$$SERVICE_NAME" --no-pager | tee -a "$$LOGFILE"
+                      systemctl status "$SERVICE_NAME" --no-pager | tee -a "$LOGFILE"
                       exit 1
                   fi
               else
@@ -408,13 +408,13 @@ write_files:
           fi
           
           log_message "🎉 GitHub Actions runner installation completed successfully"
-          log_message "Runner registered with labels: $$RUNNER_LABELS"
-          log_message "Service name: $$SERVICE_NAME"
+          log_message "Runner registered with labels: $RUNNER_LABELS"
+          log_message "Service name: $SERVICE_NAME"
       }
 
       # Execute main function with error trapping
-      trap 'log_message "❌ Script execution failed at line $$LINENO"' ERR
-      main "$$@"
+      trap 'log_message "❌ Script execution failed at line $LINENO"' ERR
+      main "$@"
   - path: /etc/ssh/sshd_config.d/custom.conf
     content: |
       UsePAM yes


### PR DESCRIPTION
## Summary
- Fixed bash variable expansion syntax errors in GitHub Actions runner setup script
- Corrected arithmetic expansion from `$$((var))` to `$((var))`
- Fixed variable references from `$$var` to `$var` where appropriate
- Maintained proper escaping for Terraform template variables

## Problem
The GitHub Actions runner installation was failing during cloud-init with:
```
/opt/setup-github-runner.sh: line 25: syntax error near unexpected token '('
/opt/setup-github-runner.sh: line 25: '            retries=$$((retries + 1))'
```

## Solution
The cloud-init template was using incorrect double dollar signs (`$$`) for bash variable expansion. This PR corrects all instances while maintaining proper escaping for Terraform template variables that need to be interpolated during deployment.

## Testing
- [x] Verified syntax is correct for bash execution
- [x] Confirmed Terraform template variables remain properly escaped
- [x] Tested locally with fixed script - runner can now be installed successfully

## Impact
This fix ensures the GitHub Actions runner can be properly installed on CLOUDSHELL VMs during cloud-init, enabling CI/CD workflows for the organization.