### PR TITLE
fix: add libsecret-1-0 dependency for draw.io installation

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -673,6 +673,7 @@ packages:
   - libicu74
   - libssl3t64
   - zlib1g
+  - libsecret-1-0  # Required for draw.io desktop application
 
 runcmd:
   - echo "runcmd executed at $(date)"


### PR DESCRIPTION
## Summary
- Fixes draw.io installation failure during cloud-init execution
- Adds missing `libsecret-1-0` package dependency
- Resolves #258

## Problem
The draw.io desktop application was failing to install on the CLOUDSHELL VM with the following error:
```
Package libsecret-1-0 is not installed.
dpkg: error processing package draw.io (--install):
 dependency problems - leaving unconfigured
```

## Solution
Added `libsecret-1-0` to the essential libraries section in the cloud-init configuration (`cloud-init/CLOUDSHELL.conf`). This ensures the dependency is installed before the draw.io installation is attempted in the runcmd section.

## Testing
- [ ] Verify libsecret-1-0 is installed during package installation phase
- [ ] Confirm draw.io installs successfully without dependency errors
- [ ] Test draw.io application launches correctly after installation

## Impact
- Fixes draw.io installation on CLOUDSHELL VM
- No breaking changes
- Minimal package addition (~200KB)

🤖 Generated with [Claude Code](https://claude.ai/code)