### PR TITLE
fix: improve Azure MCP server installation with retry logic and error visibility

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -591,10 +591,28 @@ write_files:
       nvm use --delete-prefix "v24.4.1" --silent 2>/dev/null || true
       npm config set loglevel error
 
-      PACKAGES="@anaisbetts/mcp-installer @modelcontextprotocol/server-memory @modelcontextprotocol/server-filesystem @modelcontextprotocol/server-brave-search @modelcontextprotocol/server-sequential-thinking @azure/mcp@latest @21st-dev/magic@latest @qwen-code/qwen-code@latest bash-language-server claude-auto-commit cwebp @devcontainers/cli dockerfile-language-server-nodejs eslint eslint-config-prettier gatsby-cli javascript-typescript-langserver jsonlint markdownlint markdownlint-cli markdownlint-cli2 newman opal-security playwright prettier puppeteer setup-eslint-config sql-language-server stylelint-config-prettier svgo terminalizer unified-language-server vscode-css-languageserver-bin vscode-html-languageserver-bin vscode-json-languageserver-bin yaml-language-server"
+      # Core MCP and development packages
+      PACKAGES="@anaisbetts/mcp-installer @modelcontextprotocol/server-memory @modelcontextprotocol/server-filesystem @modelcontextprotocol/server-brave-search @modelcontextprotocol/server-sequential-thinking @21st-dev/magic@latest @qwen-code/qwen-code@latest bash-language-server claude-auto-commit cwebp @devcontainers/cli dockerfile-language-server-nodejs eslint eslint-config-prettier gatsby-cli javascript-typescript-langserver jsonlint markdownlint markdownlint-cli markdownlint-cli2 newman opal-security playwright prettier puppeteer setup-eslint-config sql-language-server stylelint-config-prettier svgo terminalizer unified-language-server vscode-css-languageserver-bin vscode-html-languageserver-bin vscode-json-languageserver-bin yaml-language-server"
 
       for PKG in $PACKAGES; do
         CXXFLAGS="--std=gnu++20" npm install -g --no-save "$PKG" >/dev/null 2>&1 || true
+      done
+
+      # Install Azure MCP package with retry and better error handling
+      echo "[INFO] Installing Azure MCP server package..."
+      for attempt in 1 2 3; do
+        if npm install -g --no-save @azure/mcp@latest 2>/tmp/azure-mcp-install.log; then
+          echo "[SUCCESS] Azure MCP server installed successfully"
+          break
+        else
+          echo "[WARN] Azure MCP installation attempt $attempt failed"
+          if [ $attempt -eq 3 ]; then
+            echo "[ERROR] Failed to install Azure MCP after 3 attempts. Error log:"
+            cat /tmp/azure-mcp-install.log 2>/dev/null || echo "No error log available"
+          else
+            sleep 2
+          fi
+        fi
       done
 
       playwright install --with-deps chromium >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary
- Fixes Azure MCP server silent installation failures
- Adds retry logic and error visibility for debugging
- Resolves #263

## Problem
The Azure MCP server package (@azure/mcp) was failing to install during cloud-init execution, but the error was being suppressed with `>/dev/null 2>&1`, making it impossible to diagnose the actual issue. The warning appeared in dotfiles install.sh logs but without any error details.

## Solution
Implemented a dedicated installation process for the Azure MCP package with:
1. **Retry Logic**: 3 attempts with 2-second delays between retries
2. **Error Capture**: Errors are saved to `/tmp/azure-mcp-install.log`
3. **Visible Logging**: Clear status messages for success, warnings, and failures
4. **Error Display**: On final failure, the actual npm error is displayed

## Changes
- Separated `@azure/mcp@latest` from the main package list
- Added a dedicated installation loop with retry mechanism
- Captured stderr to a log file for debugging
- Added informative echo statements for installation status

## Testing
- [ ] Verify Azure MCP package installs successfully on first attempt
- [ ] Test retry mechanism by simulating network failures
- [ ] Confirm error logs are captured and displayed on failure
- [ ] Validate that other npm packages still install correctly

## Impact
- **Improved Diagnostics**: Installation failures are now visible and debuggable
- **Better Resilience**: Automatic retry handles transient npm/network issues
- **No Breaking Changes**: Other packages continue to install as before
- **Enhanced Logging**: Clear visibility into MCP server installation status

## Error Log Location
If installation fails, check `/tmp/azure-mcp-install.log` for detailed npm error messages.

🤖 Generated with [Claude Code](https://claude.ai/code)