### PR TITLE
Fix YAML syntax error in cloud-init CLOUDSHELL configuration

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -568,20 +568,20 @@ runcmd:
     usermod -aG docker coder
     mkdir -p /etc/coder.d /etc/systemd/system/coder.service.d
     cat > /etc/coder.d/coder.env << 'EOF'
-CODER_HTTP_ADDRESS=0.0.0.0:80
-CODER_TUNNEL_ENABLE=true
-CODER_DERP_FORCE_WEBSOCKETS=true
-CODER_TUNNEL_PREFER_IPV4=true
-EOF
+    CODER_HTTP_ADDRESS=0.0.0.0:80
+    CODER_TUNNEL_ENABLE=true
+    CODER_DERP_FORCE_WEBSOCKETS=true
+    CODER_TUNNEL_PREFER_IPV4=true
+    EOF
     cat > /etc/systemd/system/coder.service.d/override.conf << 'EOF'
-[Service]
-CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK CAP_NET_BIND_SERVICE CAP_NET_RAW CAP_NET_ADMIN
-AmbientCapabilities=CAP_IPC_LOCK CAP_NET_BIND_SERVICE CAP_NET_RAW
-TimeoutStartSec=120
-RestartSec=10
-StartLimitBurst=5
-StartLimitIntervalSec=300
-EOF
+    [Service]
+    CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK CAP_NET_BIND_SERVICE CAP_NET_RAW CAP_NET_ADMIN
+    AmbientCapabilities=CAP_IPC_LOCK CAP_NET_BIND_SERVICE CAP_NET_RAW
+    TimeoutStartSec=120
+    RestartSec=10
+    StartLimitBurst=5
+    StartLimitIntervalSec=300
+    EOF
     systemctl daemon-reload && systemctl enable coder && systemctl start coder
   - |
     #!/bin/sh
@@ -687,20 +687,20 @@ EOF
   - |
     mkdir -p /root/.config/systemd/user /root/bin
     cat > /root/.config/systemd/user/vscode-tunnel.service << 'EOF'
-[Unit]
-Description=VS Code Remote Tunnel
-After=network.target
-[Service]
-ExecStart=%h/bin/start-tunnel.sh
-Restart=always
-TimeoutStartSec=10
-[Install]
-WantedBy=default.target
-EOF
+    [Unit]
+    Description=VS Code Remote Tunnel
+    After=network.target
+    [Service]
+    ExecStart=%h/bin/start-tunnel.sh
+    Restart=always
+    TimeoutStartSec=10
+    [Install]
+    WantedBy=default.target
+    EOF
     cat > /root/bin/start-tunnel.sh << 'EOF'
-#!/bin/bash
-exec code tunnel --accept-server-license-terms --name=$(hostname)-$USER
-EOF
+    #!/bin/bash
+    exec code tunnel --accept-server-license-terms --name=$(hostname)-$USER
+    EOF
     chmod +x /root/bin/start-tunnel.sh
   - |
     bash /root/prewarm-cache.sh || true


### PR DESCRIPTION
## Summary
- Fixed critical YAML syntax error in cloud-init CLOUDSHELL configuration that was causing deployment failures
- Corrected indentation in heredoc sections within YAML literal blocks (|)
- Specifically fixed Coder environment configuration and VS Code tunnel setup heredocs

## Problem
The original error was occurring at line 580:
```
Failed loading yaml blob. Invalid format at line 580 column 1: "while scanning a simple key
CODER_HTTP_ADDRESS=0.0.0.0:80
could not find expected ':'"
```

## Solution
- All heredoc content within YAML literal blocks now properly indented with 4 spaces
- Fixed two heredoc sections:
  1. Coder environment configuration (`/etc/coder.d/coder.env`)
  2. VS Code tunnel service configuration and startup script

## Validation
- [x] Terraform validation passes
- [x] YAML syntax is now correct
- [x] All pre-commit hooks pass
- [x] No functional changes to the actual configuration content

## Impact
- Resolves cloud-init deployment failures
- Ensures CLOUDSHELL VM can be properly provisioned
- Maintains all existing functionality while fixing syntax errors

🤖 Generated with [Claude Code](https://claude.ai/code)