### PR TITLE
Rollback to commit 0cfa992

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -56,9 +56,9 @@ bootcmd:
     format_and_mount 2 ollamafs /root/.ollama no
 
 mounts:
-  - [ "LABEL=homefs", "/home", "ext4", "defaults,nofail", "0", "2" ]
-  - [ "LABEL=dockerfs", "/var/lib/docker", "ext4", "defaults,nofail", "0", "2" ]
-  - [ "LABEL=ollamafs", "/root/.ollama", "ext4", "defaults,nofail", "0", "2" ]
+  - ["LABEL=homefs", "/home", "ext4", "defaults,nofail", "0", "2"]
+  - ["LABEL=dockerfs", "/var/lib/docker", "ext4", "defaults,nofail", "0", "2"]
+  - ["LABEL=ollamafs", "/root/.ollama", "ext4", "defaults,nofail", "0", "2"]
 
 ssh_deletekeys: false
 ssh_keys:
@@ -568,20 +568,20 @@ runcmd:
     usermod -aG docker coder
     mkdir -p /etc/coder.d /etc/systemd/system/coder.service.d
     cat > /etc/coder.d/coder.env << 'EOF'
-CODER_HTTP_ADDRESS=0.0.0.0:80
-CODER_TUNNEL_ENABLE=true
-CODER_DERP_FORCE_WEBSOCKETS=true
-CODER_TUNNEL_PREFER_IPV4=true
-EOF
+    CODER_HTTP_ADDRESS=0.0.0.0:80
+    CODER_TUNNEL_ENABLE=true
+    CODER_DERP_FORCE_WEBSOCKETS=true
+    CODER_TUNNEL_PREFER_IPV4=true
+    EOF
     cat > /etc/systemd/system/coder.service.d/override.conf << 'EOF'
-[Service]
-CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK CAP_NET_BIND_SERVICE CAP_NET_RAW CAP_NET_ADMIN
-AmbientCapabilities=CAP_IPC_LOCK CAP_NET_BIND_SERVICE CAP_NET_RAW
-TimeoutStartSec=120
-RestartSec=10
-StartLimitBurst=5
-StartLimitIntervalSec=300
-EOF
+    [Service]
+    CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK CAP_NET_BIND_SERVICE CAP_NET_RAW CAP_NET_ADMIN
+    AmbientCapabilities=CAP_IPC_LOCK CAP_NET_BIND_SERVICE CAP_NET_RAW
+    TimeoutStartSec=120
+    RestartSec=10
+    StartLimitBurst=5
+    StartLimitIntervalSec=300
+    EOF
     systemctl daemon-reload && systemctl enable coder && systemctl start coder
   - |
     #!/bin/sh
@@ -687,20 +687,20 @@ EOF
   - |
     mkdir -p /root/.config/systemd/user /root/bin
     cat > /root/.config/systemd/user/vscode-tunnel.service << 'EOF'
-[Unit]
-Description=VS Code Remote Tunnel
-After=network.target
-[Service]
-ExecStart=%h/bin/start-tunnel.sh
-Restart=always
-TimeoutStartSec=10
-[Install]
-WantedBy=default.target
-EOF
+    [Unit]
+    Description=VS Code Remote Tunnel
+    After=network.target
+    [Service]
+    ExecStart=%h/bin/start-tunnel.sh
+    Restart=always
+    TimeoutStartSec=10
+    [Install]
+    WantedBy=default.target
+    EOF
     cat > /root/bin/start-tunnel.sh << 'EOF'
-#!/bin/bash
-exec code tunnel --accept-server-license-terms --name=$(hostname)-$USER
-EOF
+    #!/bin/bash
+    exec code tunnel --accept-server-license-terms --name=$(hostname)-$USER
+    EOF
     chmod +x /root/bin/start-tunnel.sh
   - |
     bash /root/prewarm-cache.sh || true


### PR DESCRIPTION
## Summary
- Rolling back infrastructure to commit 0cfa992 (15 hours ago)
- Target commit: fix: optimize CLOUDSHELL cloud-init configuration size (#277)

## Reason for Rollback
Reverting to a stable state from approximately 16 hours ago as requested.

## Changes Being Reverted
This rollback will undo the following commits:
- 456e791: Merge pull request #279 from 40docs/dev
- 80e83c6: lazy git
- 72fae46: Merge pull request #278 from 40docs/fix/yaml-syntax-cloud-init-heredoc
- be87169: fix: correct YAML syntax in cloud-init CLOUDSHELL configuration

## What Changed
The primary change is reverting the YAML syntax modifications in the CLOUDSHELL cloud-init configuration file that were made to fix heredoc indentation issues.

## Testing
- [ ] Verify infrastructure state after rollback
- [ ] Check CLOUDSHELL VM functionality
- [ ] Confirm all applications are accessible
- [ ] Validate cloud-init executes correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>