### PR TITLE
Update mounts section formatting in CLOUDSHELL.conf

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -56,9 +56,9 @@ bootcmd:
     format_and_mount 2 ollamafs /root/.ollama no
 
 mounts:
-  - [ "LABEL=homefs", "/home", "ext4", "defaults,nofail", "0", "2" ]
-  - [ "LABEL=dockerfs", "/var/lib/docker", "ext4", "defaults,nofail", "0", "2" ]
-  - [ "LABEL=ollamafs", "/root/.ollama", "ext4", "defaults,nofail", "0", "2" ]
+  - ["LABEL=homefs", "/home", "ext4", "defaults,nofail", "0", "2"]
+  - ["LABEL=dockerfs", "/var/lib/docker", "ext4", "defaults,nofail", "0", "2"]
+  - ["LABEL=ollamafs", "/root/.ollama", "ext4", "defaults,nofail", "0", "2"]
 
 ssh_deletekeys: false
 ssh_keys:


### PR DESCRIPTION
## Summary
Re-applying changes originally from commit 80e83c6

## Changes
Updates the formatting of the mounts section in cloud-init/CLOUDSHELL.conf:
- Modified mount array formatting for consistency
- Changed from `[ "LABEL=homefs", "/home", "ext4", "defaults,nofail", "0", "2" ]` 
- To: `["LABEL=homefs", "/home", "ext4", "defaults,nofail", "0", "2"]`
- Applied to all three mount entries (homefs, dockerfs, ollamafs)

## Testing
- [ ] Terraform fmt passes
- [ ] Terraform validate passes
- [ ] Mounts work correctly on CLOUDSHELL VM

## Original Commit
This restores the changes from commit 80e83c6 after rollback to 0cfa992

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>