### PR TITLE
Switch cloudshell VM to password authentication

### DIFF
--- a/cloudshell.tf
+++ b/cloudshell.tf
@@ -278,12 +278,14 @@ resource "azurerm_linux_virtual_machine" "cloudshell_vm" {
     sku       = local.vm_image["cloudshell"].sku
     version   = "latest"
   }
-  computer_name  = "CLOUDSHELL"
-  admin_username = var.cloudshell_admin_username
-  admin_ssh_key {
-    username   = var.cloudshell_admin_username
-    public_key = azapi_resource_action.cloudshell_ssh_public_key_gen[count.index].output.publicKey
-  }
+  computer_name                   = "CLOUDSHELL"
+  admin_username                  = var.cloudshell_admin_username
+  admin_password                  = var.hub_nva_password
+  disable_password_authentication = false #tfsec:ignore:AVD-AZU-0039
+  # admin_ssh_key {
+  #   username   = var.cloudshell_admin_username
+  #   public_key = azapi_resource_action.cloudshell_ssh_public_key_gen[count.index].output.publicKey
+  # }
   boot_diagnostics {
     storage_account_uri = azurerm_storage_account.cloudshell_storage_account[count.index].primary_blob_endpoint
   }


### PR DESCRIPTION
## Summary
- Changed cloudshell VM authentication from SSH key to password
- Now uses hub NVA password (var.hub_nva_password) for consistency
- Commented out SSH key authentication block

## Changes
- Modified admin authentication to use `var.hub_nva_password`
- Set `disable_password_authentication = false` explicitly
- Added tfsec:ignore comment for intentional password authentication
- Commented out the admin_ssh_key block

## Testing
- [x] terraform fmt passes
- [x] terraform validate passes
- [x] All security scans pass (with intentional ignore for password auth)

## Rationale
Azure Linux VMs only support either SSH key OR password authentication, not both. This change aligns the cloudshell VM authentication with the hub NVA configuration for consistency.

🤖 Generated with [Claude Code](https://claude.ai/code)