### PR TITLE
Fix cloud-init runcmd script failures due to existing symlinks

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -430,7 +430,7 @@ runcmd:
     export HOME=/root && /tmp/get_helm.sh
     rm -f /tmp/get_helm.sh
     mkdir -p /root/.local/state/vs-kubernetes/tools/helm/linux-amd64
-    ln -s /usr/local/bin/helm /root/.local/state/vs-kubernetes/tools/helm/linux-amd64/helm
+    ln -sf /usr/local/bin/helm /root/.local/state/vs-kubernetes/tools/helm/linux-amd64/helm
   - |
     if git clone --recurse-submodules https://github.com/40docs/.github.git /root/40docs; then
       cd /root/40docs && [ -f ./install.sh ] && { chmod +x ./install.sh; ./install.sh; } || true
@@ -508,7 +508,7 @@ runcmd:
   #- install -o root -g root -m 0755 kubectl /usr/bin/kubectl
   - |
     mkdir -p /root/.local/state/vs-kubernetes/tools/kubectl/
-    ln -s `which kubectl` /root/.local/state/vs-kubernetes/tools/kubectl/kubectl
+    ln -sf `which kubectl` /root/.local/state/vs-kubernetes/tools/kubectl/kubectl
   - curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/nektos/act/master/install.sh | bash -s -- -b /usr/local/bin
   - |
     curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip"
@@ -595,7 +595,7 @@ runcmd:
     curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube_latest_amd64.deb
     dpkg -i minikube_latest_amd64.deb
     mkdir -p /root/.local/state/vs-kubernetes/tools/minikube/linux-amd64
-    ln -s /usr/bin/minikube /root/.local/state/vs-kubernetes/tools/minikube/linux-amd64/minikube
+    ln -sf /usr/bin/minikube /root/.local/state/vs-kubernetes/tools/minikube/linux-amd64/minikube
     rm minikube_latest_amd64.deb
   - |
     curl -Lo /tmp/actionlint.sh https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash


### PR DESCRIPTION
## Summary

Fixes #287 - Resolves critical cloud-init runcmd script failures that were causing exit code 1 during system initialization.

## Problem Analysis

The cloud-init runcmd script was failing with exit code 1 due to three symlink creation commands that failed when target files already existed. Since the script uses `set -eu`, any command failure causes immediate script termination.

### Root Cause
```bash
ln -s /usr/local/bin/helm /root/.local/state/vs-kubernetes/tools/helm/linux-amd64/helm
# ↳ Fails with: "File exists" if symlink already present
```

### Impact
- ❌ Cloud-init reports script failure but continues execution
- ❌ Potential incomplete system configuration 
- ❌ Hidden failures mask critical issues
- ❌ Problems on VM reboots or cloud-init re-runs

## Solution

Added `-f` flag to force overwrite existing symlinks in three locations:

### Changes Made
```diff
- ln -s /usr/local/bin/helm /root/.local/state/vs-kubernetes/tools/helm/linux-amd64/helm
+ ln -sf /usr/local/bin/helm /root/.local/state/vs-kubernetes/tools/helm/linux-amd64/helm

- ln -s `which kubectl` /root/.local/state/vs-kubernetes/tools/kubectl/kubectl  
+ ln -sf `which kubectl` /root/.local/state/vs-kubernetes/tools/kubectl/kubectl

- ln -s /usr/bin/minikube /root/.local/state/vs-kubernetes/tools/minikube/linux-amd64/minikube
+ ln -sf /usr/bin/minikube /root/.local/state/vs-kubernetes/tools/minikube/linux-amd64/minikube
```

## Testing

### Manual Reproduction ✅
```bash
# Original failure
/bin/sh /var/lib/cloud/instance/scripts/runcmd >/dev/null 2>&1
echo $? # Returns: 1

# After fix  
ln -sf /usr/local/bin/helm /path/to/target  # Returns: 0
```

### Verification ✅
- [x] All three problematic commands now succeed
- [x] Compatible with `set -eu` strict error handling  
- [x] Idempotent behavior on multiple runs
- [x] Maintains VS Code Kubernetes extension compatibility

## Risk Assessment

**Risk Level:** 🟢 **Low**
- Non-breaking change (adds `-f` flag only)
- Backward compatible with existing deployments
- No functional changes to symlink targets
- Improves reliability and reduces false failures

## Files Changed
- `cloud-init/CLOUDSHELL.conf` - Lines 433, 511, 598

## Next Steps
1. Merge this PR to fix the immediate symlink issues
2. Monitor #287 for additional cloud-init script analysis
3. Consider implementing comprehensive cloud-init error handling improvements

## Related Issues
- Fixes #287 - [CRITICAL] Cloud-init runcmd script fails with exit code 1
- Related to dash/bash compatibility improvements in infrastructure documentation

---
🤖 Generated with [Claude Code](https://claude.ai/code)