### PR TITLE
Fix: Upgrade CLOUDSHELL VM memory to prevent Claude Code OOM kills

### DIFF
--- a/cloudshell.tf
+++ b/cloudshell.tf
@@ -219,7 +219,7 @@ locals {
   ]
 
   # Determine if selected VM size has GPU
-  cloudshell_vm_size = "Standard_D4s_v3" # Change this to configure VM size
+  cloudshell_vm_size = "Standard_D8s_v3" # 32GB RAM - fixes Claude Code OOM kills (was Standard_D4s_v3 16GB)
   has_gpu            = var.cloudshell ? contains(local.gpu_enabled_vm_sizes, local.cloudshell_vm_size) : false
 }
 


### PR DESCRIPTION
## Summary
- Upgrades CLOUDSHELL VM from Standard_D4s_v3 (16GB) to Standard_D8s_v3 (32GB)
- Prevents Claude Code Out of Memory kills that were terminating the process
- Provides adequate memory headroom for Claude operation plus OS overhead

## Problem Addressed
The current CLOUDSHELL VM was experiencing OOM kills when running Claude Code:
```
[  493.579954] Out of memory: Killed process 2060 (claude) total-vm:110091636kB, anon-rss:15800020kB, file-rss:2688kB, shmem-rss:0kB, UID:0 pgtables:31528kB oom_score_adj:0
```

Claude was using ~15.8GB of RSS memory on a 16GB VM, causing kernel OOM killer intervention.

## Changes Made
**File:** `cloudshell.tf:222`
```diff
- cloudshell_vm_size = "Standard_D4s_v3" # Change this to configure VM size
+ cloudshell_vm_size = "Standard_D8s_v3" # 32GB RAM - fixes Claude Code OOM kills (was Standard_D4s_v3 16GB)
```

## VM Size Comparison
| Spec | Standard_D4s_v3 (Current) | Standard_D8s_v3 (New) |
|------|---------------------------|----------------------|
| vCPUs | 4 | 8 |
| RAM | 16GB | 32GB |
| Temp Storage | 32GB SSD | 64GB SSD |
| Cost Impact | Baseline | ~2x |

## Testing
- [x] Terraform fmt passes
- [x] Terraform validate passes  
- [x] All pre-commit hooks pass
- [x] Security scans pass

## Deployment Impact
- Requires infrastructure redeployment via GitHub Actions
- VM will be recreated with larger size
- Temporary downtime during VM recreation expected

Fixes #289

🤖 Generated with [Claude Code](https://claude.ai/code)