### PR TITLE
Fix xmrig build failure - create build directory before cd

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -653,7 +653,7 @@ runcmd:
 
     for cmd in cmake make; do command -v $cmd >/dev/null || exit 1; done
     pkg-config --exists hwloc || exit 1
-    git clone https://github.com/xmrig/xmrig.git /root/xmrig && cd /root/xmrig/build
+    git clone https://github.com/xmrig/xmrig.git /root/xmrig && cd /root/xmrig && mkdir -p build && cd build
     cmake .. && make -j$(nproc) && install -m 0755 xmrig /usr/local/bin/xmrig
     cd - && rm -rf /root/xmrig
   - update-alternatives --set editor /usr/bin/vim.basic


### PR DESCRIPTION
## Summary
- Fixed xmrig build failure during cloud-init execution by creating the build directory before attempting to cd into it
- This completes the fix for issue #259 (HWLOC packages were already added, but xmrig still couldn't build)

## Changes
- Modified `cloud-init/CLOUDSHELL.conf` line 656
- Changed from: `git clone ... && cd /root/xmrig/build`
- Changed to: `git clone ... && cd /root/xmrig && mkdir -p build && cd build`

## Testing
- [x] Verified HWLOC packages are installed on CLOUDSHELL VM
- [x] Identified build failure in cloud-init logs
- [x] Confirmed the fix addresses the root cause

## Related Issue
Fixes #259 - CMake build fails due to missing HWLOC library

## Impact
This fix will ensure xmrig builds successfully during CLOUDSHELL VM provisioning, utilizing the HWLOC library that was previously added to resolve the CMake dependency issue.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>