### PR TITLE
Fix draw.io installation failure due to missing libsecret-1-0 dependency

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -589,8 +589,9 @@ runcmd:
       | jq -r --arg ARCH "$ARCH" \
           '.assets[] | select(.name | contains("deb") and contains($ARCH)) | .browser_download_url')
     curl -s -L "$${download_url}" -o /tmp/drawio.deb
-    dpkg -i /tmp/drawio.deb
-    rm /tmp/drawio.deb
+    # Install with apt to resolve dependencies automatically (requires ./ prefix for local files)
+    apt-get update && apt-get install -y ./tmp/drawio.deb || (apt-get install -f -y && dpkg -i /tmp/drawio.deb)
+    rm -f /tmp/drawio.deb
   - |
     curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube_latest_amd64.deb
     dpkg -i minikube_latest_amd64.deb


### PR DESCRIPTION
## Summary
- Fixed draw.io installation failure during cloud-init by using apt-get instead of dpkg
- apt-get automatically resolves and installs dependencies including libsecret-1-0
- Added fallback mechanism for dependency resolution

## Changes
- Modified `cloud-init/CLOUDSHELL.conf` lines 592-594
- Changed from: `dpkg -i /tmp/drawio.deb`  
- Changed to: `apt-get install -y ./tmp/drawio.deb` with fallback to `apt-get install -f`

## Root Cause
The issue occurred because:
1. draw.io was installed using `dpkg -i` which doesn't resolve dependencies
2. Even though libsecret-1-0 was in the packages list, the runcmd section might execute before all packages are fully installed
3. This left draw.io in an unconfigured state

## Solution
Using `apt-get install` with a local .deb file (requires ./ prefix in Ubuntu 24.04) automatically:
- Checks for dependencies
- Installs missing dependencies from repositories
- Properly configures the package

## Testing
- [x] Verified libsecret-1-0 is available in Ubuntu 24.04 repositories
- [x] Confirmed libsecret-1-0 is already in packages list (line 373)
- [x] Verified draw.io is currently installed on CLOUDSHELL VM
- [x] Tested apt-get install syntax with local .deb files

## Related Issue
Fixes #258 - draw.io installation fails due to missing libsecret-1-0 dependency

## Impact
This ensures draw.io will be properly installed with all dependencies during future CLOUDSHELL VM provisioning.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>