### PR TITLE
Fix Coder dev tunnel socket permission denied error

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -575,7 +575,7 @@ runcmd:
     cat > /etc/systemd/system/coder.service.d/override.conf << 'EOF'
     [Service]
     CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK CAP_NET_BIND_SERVICE CAP_NET_RAW CAP_NET_ADMIN
-    AmbientCapabilities=CAP_IPC_LOCK CAP_NET_BIND_SERVICE CAP_NET_RAW
+    AmbientCapabilities=CAP_IPC_LOCK CAP_NET_BIND_SERVICE CAP_NET_RAW CAP_NET_ADMIN
     TimeoutStartSec=120
     RestartSec=10
     StartLimitBurst=5


### PR DESCRIPTION
## Summary
- Fixed Coder service socket permission denied errors when establishing dev tunnels
- Added CAP_NET_ADMIN to AmbientCapabilities in the systemd service override

## Root Cause
The Coder service was encountering "socket: permission denied" errors when trying to establish dev tunnels because:
1. The service runs as the non-root 'coder' user
2. Creating certain network sockets requires CAP_NET_ADMIN capability
3. CAP_NET_ADMIN was in CapabilityBoundingSet but not in AmbientCapabilities
4. Without ambient capabilities, the non-root process cannot use the capability

## Solution
Added CAP_NET_ADMIN to the AmbientCapabilities line in the systemd service override configuration. This allows the Coder process to create the necessary network sockets for dev tunnels.

## Changes
- Modified `cloud-init/CLOUDSHELL.conf` line 578
- Changed from: `AmbientCapabilities=CAP_IPC_LOCK CAP_NET_BIND_SERVICE CAP_NET_RAW`
- Changed to: `AmbientCapabilities=CAP_IPC_LOCK CAP_NET_BIND_SERVICE CAP_NET_RAW CAP_NET_ADMIN`

## Testing
- [x] Applied fix to running CLOUDSHELL VM
- [x] Restarted Coder service successfully
- [x] Verified no permission denied errors after fix
- [x] Confirmed Coder service is running properly

## Related Issue
Fixes #261 - Coder dev tunnel socket permission denied error

## Impact
This ensures Coder can establish dev tunnels properly, enabling remote VS Code connections and developer access to the CLOUDSHELL VM.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>