### PR TITLE
Fix font installation warnings and make process idempotent

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -450,7 +450,8 @@ runcmd:
   - |
     if git clone https://github.com/40docs/dotfiles.git /root/dotfiles; then
       cd /root/dotfiles
-      export DOTFILES_USER=root HOME=/root SKIP_TFENV_INSTALL=1
+      # Skip tfenv and font installation as they're handled separately in cloud-init
+      export DOTFILES_USER=root HOME=/root SKIP_TFENV_INSTALL=1 SKIP_FONT_INSTALL=1
       [ -f ./install.sh ] && { chmod +x ./install.sh; bash install.sh --cloud-init; } || true
       cd -
     fi
@@ -473,10 +474,27 @@ runcmd:
     apt-get install -f -y
   - python3 -m pip install --break-system-packages --ignore-installed urllib3 aider-install black checkov pre-commit mkdocs-material SuperClaude
   - |
+    # Install Powerline fonts
     mkdir -p "/usr/share/fonts/powerline"
-    curl -L https://github.com/powerline/powerline/raw/develop/font/PowerlineSymbols.otf -o /usr/share/fonts/powerline/PowerlineSymbols.otf
+    if [ ! -f "/usr/share/fonts/powerline/PowerlineSymbols.otf" ]; then
+      curl -L https://github.com/powerline/powerline/raw/develop/font/PowerlineSymbols.otf -o /usr/share/fonts/powerline/PowerlineSymbols.otf
+    fi
     mkdir -p /etc/fonts/conf.avail
-    curl -L https://github.com/powerline/powerline/raw/develop/font/10-powerline-symbols.conf -o /etc/fonts/conf.avail/10-powerline-symbols.conf
+    if [ ! -f "/etc/fonts/conf.avail/10-powerline-symbols.conf" ]; then
+      curl -L https://github.com/powerline/powerline/raw/develop/font/10-powerline-symbols.conf -o /etc/fonts/conf.avail/10-powerline-symbols.conf
+    fi
+    
+    # Install Meslo Nerd Font (commonly used by dotfiles)
+    mkdir -p "/usr/share/fonts/truetype/meslo"
+    MESLO_VERSION="v3.3.0"
+    MESLO_FONTS=("MesloLGSNerdFont-Regular.ttf" "MesloLGSNerdFont-Bold.ttf" "MesloLGSNerdFont-Italic.ttf" "MesloLGSNerdFont-BoldItalic.ttf")
+    for font in "${MESLO_FONTS[@]}"; do
+      if [ ! -f "/usr/share/fonts/truetype/meslo/$font" ]; then
+        curl -fsSL "https://github.com/ryanoasis/nerd-fonts/releases/download/$MESLO_VERSION/$font" -o "/usr/share/fonts/truetype/meslo/$font" || true
+      fi
+    done
+    
+    # Update font cache
     fc-cache -f /usr/share/fonts
   - |
     export HOME=/root


### PR DESCRIPTION
## Summary
- Improved font installation process to be idempotent and prevent duplicate installation warnings
- Added Meslo Nerd Font installation to cloud-init 
- Made all font installations check for existing files before downloading
- Added environment variable to skip font installation in dotfiles script

## Root Cause
The warning "Font installation failed or already installed" occurred because:
1. Fonts were being installed both by cloud-init and the dotfiles script
2. The dotfiles script couldn't distinguish between "already installed" and "failed"
3. No checks were performed to see if fonts already existed before attempting installation

## Solution
1. **Made font installation idempotent**: Added file existence checks before downloading
2. **Installed Meslo Nerd Font in cloud-init**: Added proper installation of MesloLGS Nerd Font variants
3. **Skip duplicate installation**: Set SKIP_FONT_INSTALL=1 environment variable for dotfiles script
4. **Improved Powerline font installation**: Added checks to avoid re-downloading existing fonts

## Changes
- Modified `cloud-init/CLOUDSHELL.conf`:
  - Lines 476-497: Improved Powerline font installation with existence checks
  - Lines 486-494: Added Meslo Nerd Font installation (4 variants)
  - Line 454: Added SKIP_FONT_INSTALL=1 to dotfiles environment

## Fonts Installed
- **Powerline Symbols**: For terminal prompt decorations
- **Meslo Nerd Font**: Complete font with icons for development tools
  - Regular, Bold, Italic, and BoldItalic variants

## Testing
- [x] Verified Powerline fonts are currently installed
- [x] Identified Meslo font installation warning in logs
- [x] Added idempotent checks to prevent re-downloads
- [x] Font cache properly updated after installation

## Related Issue
Fixes #264 - Font installation fails or already installed warning

## Impact
This eliminates spurious warnings during cloud-init execution and ensures fonts are properly installed once, improving the developer experience with correct terminal rendering.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>