### PR TITLE
fix: escape bash variables in terraform templatefile

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -488,9 +488,9 @@ runcmd:
     mkdir -p "/usr/share/fonts/truetype/meslo"
     MESLO_VERSION="v3.3.0"
     MESLO_FONTS=("MesloLGSNerdFont-Regular.ttf" "MesloLGSNerdFont-Bold.ttf" "MesloLGSNerdFont-Italic.ttf" "MesloLGSNerdFont-BoldItalic.ttf")
-    for font in "${MESLO_FONTS[@]}"; do
+    for font in "$${MESLO_FONTS[@]}"; do
       if [ ! -f "/usr/share/fonts/truetype/meslo/$font" ]; then
-        curl -fsSL "https://github.com/ryanoasis/nerd-fonts/releases/download/$MESLO_VERSION/$font" -o "/usr/share/fonts/truetype/meslo/$font" || true
+        curl -fsSL "https://github.com/ryanoasis/nerd-fonts/releases/download/$${MESLO_VERSION}/$font" -o "/usr/share/fonts/truetype/meslo/$font" || true
       fi
     done
     


### PR DESCRIPTION
## Summary

Fixes terraform plan failure caused by unescaped bash array syntax in cloud-init template.

## Problem

The GitHub Actions infrastructure workflow was failing with:



The issue was on line 491 where  bash array syntax was conflicting with Terraform's template variable interpolation syntax.

## Solution

- Escaped  as  in cloud-init template
- Escaped  as  in cloud-init template
- This allows bash to properly expand the variables while preventing Terraform from interpreting them as template variables

## Testing

- [x] [0m[1mInitializing provider plugins...[0m
- Reusing previous version of hashicorp/local from the dependency lock file
- Reusing previous version of hashicorp/http from the dependency lock file
- Reusing previous version of hashicorp/kubernetes from the dependency lock file
- Reusing previous version of loafoe/htpasswd from the dependency lock file
- Reusing previous version of hashicorp/random from the dependency lock file
- Reusing previous version of hashicorp/tls from the dependency lock file
- Reusing previous version of hashicorp/null from the dependency lock file
- Reusing previous version of hashicorp/external from the dependency lock file
- Reusing previous version of integrations/github from the dependency lock file
- Reusing previous version of hashicorp/azurerm from the dependency lock file
- Reusing previous version of fluxcd/flux from the dependency lock file
- Reusing previous version of azure/azapi from the dependency lock file
- Using previously-installed hashicorp/http v3.5.0
- Using previously-installed loafoe/htpasswd v1.2.1
- Using previously-installed hashicorp/tls v4.1.0
- Using previously-installed hashicorp/external v2.3.5
- Using previously-installed integrations/github v6.6.0
- Using previously-installed hashicorp/azurerm v4.41.0
- Using previously-installed azure/azapi v2.6.0
- Using previously-installed hashicorp/local v2.5.3
- Using previously-installed hashicorp/kubernetes v2.38.0
- Using previously-installed hashicorp/random v3.7.2
- Using previously-installed hashicorp/null v3.2.4
- Using previously-installed fluxcd/flux v1.6.4

[0m[1m[32mTerraform has been successfully initialized![0m[32m[0m
[0m[32m
You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.[0m passes
- [x] [32m[1mSuccess![0m The configuration is valid.
[0m passes  
- [x]  executed
- [x] No syntax errors in cloud-init template

## Context

In Terraform  function,  syntax is used for template variable interpolation. To include literal  in the output (for bash variables), you must escape it as .

This fix ensures the font installation script works correctly while maintaining terraform template functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)