### PR TITLE
Fix cloud-init bash/dash compatibility issues

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -162,7 +162,7 @@ write_files:
           export GITHUB_TOKEN="${var_github_token}"
           export RUNNER_GROUP="${var_runner_group}"
           LABELS_BASE="${var_runner_labels}"
-          if [[ "$LABELS_BASE" != *"CLOUDSHELL"* ]]; then
+          if [ "$LABELS_BASE" = "${LABELS_BASE##*CLOUDSHELL*}" ]; then
             export RUNNER_LABELS="$LABELS_BASE,CLOUDSHELL,cloudshell"
           else
             export RUNNER_LABELS="$LABELS_BASE"
@@ -210,7 +210,7 @@ write_files:
           [ -z "$REG_TOKEN" ] || [ "$REG_TOKEN" = "null" ] && { log "Token failed"; exit 1; }
 
           CONFIG_CMD="sudo -u ubuntu ./config.sh --url \"$ORG_URL\" --token \"$REG_TOKEN\" --name \"$RUNNER_NAME\" --work \"_work\" --unattended --replace --labels \"$RUNNER_LABELS\""
-          [[ -n "$RUNNER_GROUP" ]] && CONFIG_CMD="$CONFIG_CMD --runnergroup \"$RUNNER_GROUP\""
+          [ -n "$RUNNER_GROUP" ] && CONFIG_CMD="$CONFIG_CMD --runnergroup \"$RUNNER_GROUP\""
 
           eval "$CONFIG_CMD" || { log "Config failed"; exit 1; }
           ./svc.sh install ubuntu && systemctl daemon-reload && systemctl enable "$SERVICE_NAME" && systemctl start "$SERVICE_NAME"
@@ -276,12 +276,12 @@ write_files:
       set -eu
       NVM_DIR="/usr/local/nvm"
 
-      [[ ! -d "$${NVM_DIR}/.git" ]] && git clone -q https://github.com/nvm-sh/nvm.git "$${NVM_DIR}" || git -C "$${NVM_DIR}" pull -q || true
+      [ ! -d "$${NVM_DIR}/.git" ] && git clone -q https://github.com/nvm-sh/nvm.git "$${NVM_DIR}" || git -C "$${NVM_DIR}" pull -q || true
       [ -f "$${NVM_DIR}/nvm.sh" ] && . "$${NVM_DIR}/nvm.sh" || exit 0
 
       unset NPM_CONFIG_PREFIX
       export npm_config_prefix="" npm_config_globalconfig=""
-      [[ -f "/root/.npmrc" ]] && mv /root/.npmrc "/root/.npmrc.bak"
+      [ -f "/root/.npmrc" ] && mv /root/.npmrc "/root/.npmrc.bak"
 
       nvm install node --silent && nvm alias default node && nvm use default --delete-prefix --silent || exit 0
       nvm use --delete-prefix "v24.4.1" --silent 2>/dev/null || true
@@ -487,8 +487,7 @@ runcmd:
     # Install Meslo Nerd Font (commonly used by dotfiles)
     mkdir -p "/usr/share/fonts/truetype/meslo"
     MESLO_VERSION="v3.3.0"
-    MESLO_FONTS=("MesloLGSNerdFont-Regular.ttf" "MesloLGSNerdFont-Bold.ttf" "MesloLGSNerdFont-Italic.ttf" "MesloLGSNerdFont-BoldItalic.ttf")
-    for font in "$${MESLO_FONTS[@]}"; do
+    for font in MesloLGSNerdFont-Regular.ttf MesloLGSNerdFont-Bold.ttf MesloLGSNerdFont-Italic.ttf MesloLGSNerdFont-BoldItalic.ttf; do
       if [ ! -f "/usr/share/fonts/truetype/meslo/$font" ]; then
         curl -fsSL "https://github.com/ryanoasis/nerd-fonts/releases/download/$${MESLO_VERSION}/$font" -o "/usr/share/fonts/truetype/meslo/$font" || true
       fi


### PR DESCRIPTION
## Summary

This PR resolves critical cloud-init configuration issues that were causing deployment failures on the CLOUDSHELL VM due to bash/dash shell compatibility problems.

## Problem

The cloud-init configuration was failing with:
```
/var/lib/cloud/instance/scripts/runcmd: 114: Syntax error: "(" unexpected
```

**Root Cause**: Cloud-init's `runcmd` section executes commands using `/bin/sh` (dash), not bash. The configuration contained bash-specific syntax that's incompatible with dash shell.

## Changes Made

### 1. Fixed Bash Array Syntax (lines 490-491)
- ❌ **Before**: `MESLO_FONTS=("font1" "font2")` and `"${MESLO_FONTS[@]}"`
- ✅ **After**: Direct iteration `for font in font1 font2 font3 font4`

### 2. Converted Double Bracket Conditionals
- ❌ **Before**: `[[ "$LABELS_BASE" != *"CLOUDSHELL"* ]]`
- ✅ **After**: `[ "$LABELS_BASE" = "${LABELS_BASE##*CLOUDSHELL*}" ]`

### 3. Fixed Pattern Matching Syntax
- ❌ **Before**: `[[ -n "$RUNNER_GROUP" ]]`
- ✅ **After**: `[ -n "$RUNNER_GROUP" ]`

### 4. Corrected Directory Tests
- ❌ **Before**: `[[ ! -d "$NVM_DIR/.git" ]]`
- ✅ **After**: `[ ! -d "$NVM_DIR/.git" ]`

### 5. Updated File Tests
- ❌ **Before**: `[[ -f "/root/.npmrc" ]]`
- ✅ **After**: `[ -f "/root/.npmrc" ]`

## Technical Details

All changes convert bash-specific syntax to POSIX-compatible alternatives that work with both bash and dash shells. This ensures cloud-init can execute the configuration successfully without syntax errors.

## Testing

- [x] `terraform fmt` passes
- [x] `terraform validate` passes
- [x] No bash-specific syntax remains in cloud-init configuration
- [x] All conditional logic preserved with POSIX equivalents

## Impact

- ✅ Fixes CLOUDSHELL VM deployment failures
- ✅ Ensures cloud-init completes successfully
- ✅ Maintains all functionality while improving compatibility
- ✅ No breaking changes to existing behavior

🤖 Generated with [Claude Code](https://claude.ai/code)