### PR TITLE
fix: resolve cloud-init template variable quoting issues

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -543,12 +543,12 @@ runcmd:
   - |
     IMAGES="ghcr.io/40docs/devcontainer:latest mcp/memory:latest mcp/git:latest mcp/time:latest mcp/sequentialthinking:latest mcp/filesystem:latest kubernetes-mcp-server:latest hashicorp/terraform-mcp-server:latest ghcr.io/github/github-mcp-server"
     for IMG in $IMAGES; do docker pull "$IMG" >/dev/null 2>&1 || true; done
-    usermod -aG docker ${var_admin_username} || true
+    usermod -aG docker "${var_admin_username}" || true
 %{ if var_has_gpu ~}
     docker run --privileged --rm tonistiigi/binfmt --install all || true
   - |
     # Enable NVIDIA persistence daemon for stable GPU memory management
-    nvidia-persistenced --user ${var_admin_username}
+    nvidia-persistenced --user "${var_admin_username}"
     systemctl enable nvidia-persistenced
     # Set GPU performance mode
     nvidia-smi -pm ENABLED || echo "Performance mode setting may need manual intervention"
@@ -558,7 +558,7 @@ runcmd:
     # Wait for Docker to fully restart and recognize nvidia runtime
     sleep 10
     # Add user to render group for GPU device access
-    usermod -aG render ${var_admin_username}
+    usermod -aG render "${var_admin_username}"
     # Set up udev rules for GPU device permissions
     echo 'KERNEL=="nvidia*", GROUP="render", MODE="0666"' > /etc/udev/rules.d/70-nvidia.rules
     echo 'KERNEL=="nvidia_uvm", GROUP="render", MODE="0666"' >> /etc/udev/rules.d/70-nvidia.rules


### PR DESCRIPTION
## Summary

This PR fixes critical cloud-init template variable quoting issues that were causing VM initialization failures with "parameter not set" errors.

### Changes Made
- Fixed three instances of unquoted `${var_admin_username}` variables in `cloud-init/CLOUDSHELL.conf`
- Added proper double quotes: `"${var_admin_username}"`
- Resolves dash/bash compatibility issues in cloud-init `runcmd` section

### Root Cause
Cloud-init's `runcmd` section executes commands using `/bin/sh` (dash), not bash. Unquoted template variables like `${var_admin_username}` cause parameter expansion failures in dash when the variable contains special characters or spaces.

### Impact
- Prevents "parameter not set" errors during VM initialization
- Ensures reliable cloud-init execution across all CLOUDSHELL VM deployments
- Maintains compatibility with both bash and dash shell environments

### Testing
- [x] All pre-commit hooks pass
- [x] Cloud-init file size validation passes
- [x] Template variable syntax validated
- [x] Changes follow POSIX shell compatibility guidelines

### Files Changed
- `cloud-init/CLOUDSHELL.conf` - Added proper quoting for template variables in runcmd section

🤖 Generated with [Claude Code](https://claude.ai/code)