### PR TITLE
Fix: Resolve Meslo Nerd Font 404 errors in cloud-init (Issue #305)

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -547,12 +547,19 @@ runcmd:
     # Install Meslo Nerd Font (commonly used by dotfiles)
     mkdir -p "/usr/share/fonts/truetype/meslo"
     MESLO_VERSION="v3.3.0"
-    for font in MesloLGSNerdFont-Regular.ttf MesloLGSNerdFont-Bold.ttf MesloLGSNerdFont-Italic.ttf MesloLGSNerdFont-BoldItalic.ttf
-    do
-      if [ ! -f "/usr/share/fonts/truetype/meslo/$font" ]; then
-        curl -fsSL "https://github.com/ryanoasis/nerd-fonts/releases/download/$${MESLO_VERSION}/$font" -o "/usr/share/fonts/truetype/meslo/$font" || true
+    
+    # Download and extract Meslo fonts from zip archive (individual files not available)
+    if ! ls /usr/share/fonts/truetype/meslo/MesloLGS*.ttf >/dev/null 2>&1; then
+      TEMP_DIR=$(mktemp -d)
+      if curl -fsSL "https://github.com/ryanoasis/nerd-fonts/releases/download/$${MESLO_VERSION}/Meslo.zip" -o "$TEMP_DIR/Meslo.zip"; then
+        unzip -q "$TEMP_DIR/Meslo.zip" -d "$TEMP_DIR"
+        # Install MesloLGS variants specifically
+        find "$TEMP_DIR" -name "MesloLGS*.ttf" -exec cp {} /usr/share/fonts/truetype/meslo/ \; 2>/dev/null || true
+        # Also install regular Meslo variants if needed
+        find "$TEMP_DIR" -name "Meslo*.ttf" -exec cp {} /usr/share/fonts/truetype/meslo/ \; 2>/dev/null || true
       fi
-    done
+      rm -rf "$TEMP_DIR"
+    fi
 
     # Update font cache
     fc-cache -f /usr/share/fonts


### PR DESCRIPTION
## Summary
- Fixed curl 404 errors during CLOUDSHELL VM cloud-init execution
- Changed Meslo Nerd Font installation to download from zip archive instead of individual files
- Resolves issue #305 and should fix issue #264

## Problem
The cloud-init script was attempting to download individual Meslo Nerd Font .ttf files from the Nerd Fonts v3.3.0 release, but these files are not available as individual downloads. This resulted in four 404 errors during cloud-init execution:
```
curl: (22) The requested URL returned error: 404
```

**Related Impact on Issue #264:**
The failed cloud-init font installation also caused dotfiles to show font warnings:
```
[WARN] [dotfiles install.sh] Font installation failed or already installed
```

## Solution
Modified the font installation script to:
1. Download the complete `Meslo.zip` archive from the release
2. Extract the archive to a temporary directory
3. Copy MesloLGS and other Meslo font variants to the fonts directory
4. Clean up temporary files

## Changes
- Updated `/cloud-init/CLOUDSHELL.conf` to use the zip archive approach
- Added proper error handling and cleanup
- Maintained backwards compatibility by checking if fonts already exist

## Testing
- [x] Verified the Meslo.zip URL returns HTTP 302 (valid redirect)
- [x] Terraform fmt passes
- [x] Terraform validate passes

## Impact
- Eliminates 404 errors during cloud-init execution
- Ensures Meslo Nerd Fonts are properly installed on CLOUDSHELL VM
- Should resolve font installation warnings in dotfiles (Issue #264)
- Improves cloud-init reliability and reduces noise in logs

## Expected Result for Issue #264
Once fonts are properly installed by cloud-init, the Oh My Posh font installation in dotfiles should either:
- Succeed silently (fonts available)
- Detect fonts are already installed and skip

Fixes #305
Related to #264

🤖 Generated with Claude Code