### PR TITLE
Fix: Correct var_admin_username interpolation in cloud-init (Issue #306)

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -608,12 +608,12 @@ runcmd:
     do 
         docker pull "$IMG" >/dev/null 2>&1 || true
     done
-    usermod -aG docker $${var_admin_username} || true
+    usermod -aG docker ${var_admin_username} || true
 %{ if var_has_gpu ~}
     docker run --privileged --rm tonistiigi/binfmt --install all || true
   - |
     # Enable NVIDIA persistence daemon for stable GPU memory management
-    nvidia-persistenced --user $${var_admin_username}
+    nvidia-persistenced --user ${var_admin_username}
     systemctl enable nvidia-persistenced
     # Set GPU performance mode
     nvidia-smi -pm ENABLED || echo "Performance mode setting may need manual intervention"
@@ -623,7 +623,7 @@ runcmd:
     # Wait for Docker to fully restart and recognize nvidia runtime
     sleep 10
     # Add user to render group for GPU device access
-    usermod -aG render $${var_admin_username}
+    usermod -aG render ${var_admin_username}
     # Set up udev rules for GPU device permissions
     echo 'KERNEL=="nvidia*", GROUP="render", MODE="0666"' > /etc/udev/rules.d/70-nvidia.rules
     echo 'KERNEL=="nvidia_uvm", GROUP="render", MODE="0666"' >> /etc/udev/rules.d/70-nvidia.rules


### PR DESCRIPTION
## Summary
- Fixed Terraform template variable interpolation for var_admin_username
- Changed from escaped syntax `$${var_admin_username}` to `${var_admin_username}`
- Resolves cloud-init scripts_user module failure
- Fixes issue #306

## Problem
The cloud-init script was failing with the error:
```
/var/lib/cloud/instance/scripts/runcmd: 184: var_admin_username: parameter not set
```

This occurred because the template was using `$${var_admin_username}` which tells Terraform to output the literal string `${var_admin_username}` instead of interpolating the actual value.

## Root Cause
In Terraform templatefile syntax:
- `$${variable}` = Output literal `${variable}` text (escaped)
- `${variable}` = Interpolate the actual variable value

The cloud-init template was incorrectly using the escaped syntax, causing the literal string to appear in the rendered script instead of the actual admin username value.

## Solution
Changed three occurrences from `$${var_admin_username}` to `${var_admin_username}`:
1. Line 611: `usermod -aG docker` command
2. Line 616: `nvidia-persistenced --user` command (GPU conditional)
3. Line 626: `usermod -aG render` command (GPU conditional)

## Testing
- [x] Terraform fmt passes
- [x] Terraform validate passes
- [x] Template syntax verified against Terraform documentation

## Impact
- Ensures var_admin_username is properly interpolated with actual value
- Fixes scripts_user module execution in cloud-init
- Allows proper user group assignments for docker and GPU access

## Verification
After deployment, the rendered cloud-init script should contain the actual username (e.g., `azureuser`) instead of the literal `${var_admin_username}` string.

Fixes #306

🤖 Generated with Claude Code