### PR TITLE
Fix: Install Claude CLI before dotfiles to prevent warnings (Issue #307)

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -506,6 +506,18 @@ runcmd:
       cd /root/.tfenv && git pull -q 2>/dev/null || true && cd -
     fi
   - |
+    # Install Claude CLI before dotfiles to prevent "binary not found" warnings
+    export HOME=/root
+    curl -fsSL https://claude.ai/install.sh | bash -s 1.0.81
+    CLAUDE_LINK="/root/.local/bin/claude"
+    CLAUDE_TARGET=$(readlink "$CLAUDE_LINK" || true)
+    if [ -n "$CLAUDE_TARGET" ] && [ -e "$CLAUDE_TARGET" ]; then
+      REL_TARGET=$(realpath --relative-to="$(dirname "$CLAUDE_LINK")" "$CLAUDE_TARGET")
+      ln -sf "$REL_TARGET" "$CLAUDE_LINK"
+    fi
+    echo "export ENABLE_BACKGROUND_TASKS=1" >> /root/.bashrc
+    echo "export ENABLE_BACKGROUND_TASKS=1" >> /root/.zshrc
+  - |
     if git clone https://github.com/40docs/dotfiles.git /root/dotfiles; then
       cd /root/dotfiles
       # Skip tfenv and font installation as they're handled separately in cloud-init
@@ -753,17 +765,6 @@ runcmd:
     install lw_report_gen /usr/local/bin
     rm lw_report_gen
   - curl -s https://ohmyposh.dev/install.sh | HOME=/root bash -s -- -d /usr/local/bin -t /var/local/themes
-  - |
-    export HOME=/root
-    curl -fsSL https://claude.ai/install.sh | bash -s 1.0.81
-    CLAUDE_LINK="/root/.local/bin/claude"
-    CLAUDE_TARGET=$(readlink "$CLAUDE_LINK" || true)
-    if [ -n "$CLAUDE_TARGET" ] && [ -e "$CLAUDE_TARGET" ]; then
-      REL_TARGET=$(realpath --relative-to="$(dirname "$CLAUDE_LINK")" "$CLAUDE_TARGET")
-      ln -sf "$REL_TARGET" "$CLAUDE_LINK"
-    fi
-    echo "export ENABLE_BACKGROUND_TASKS=1" >> /root/.bashrc
-    echo "export ENABLE_BACKGROUND_TASKS=1" >> /root/.zshrc
   - curl -fsSL https://raw.githubusercontent.com/smtg-ai/claude-squad/main/install.sh | HOME=/root bash -s --
   - |
     export HOME=/root PATH="/root/.local/bin:$PATH"


### PR DESCRIPTION
## Summary
- Moved Claude CLI installation to occur before dotfiles installation
- Prevents \"Claude binary not found\" warnings during cloud-init execution
- Improves cloud-init execution experience and reduces log noise
- Fixes issue #307

## Problem
During cloud-init execution, the dotfiles install.sh script was generating warnings:
```
[WARN] [dotfiles install.sh] Claude binary not found in any expected locations
[WARN] [dotfiles install.sh] Claude binary not found. Installing Claude CLI...
```

This occurred because:
1. Dotfiles installation happened at line ~521
2. Claude CLI installation happened much later at line ~758
3. When dotfiles checked for Claude binary, it wasn't installed yet

## Solution
**Moved Claude CLI installation to before dotfiles installation:**
- Relocated the entire Claude installation block from line 758 to line 509
- Added explanatory comment about preventing binary not found warnings
- Maintains all original Claude installation logic and symlink handling

## Changes
- **Removed**: Claude installation from line 758 (after other tools)
- **Added**: Claude installation at line 509 (before dotfiles)
- **Preserved**: All Claude installation logic including:
  - Binary installation via `curl -fsSL https://claude.ai/install.sh`
  - Symlink creation and relative path handling
  - Environment variable exports for bash/zsh

## Testing
- [x] Terraform fmt passes
- [x] Terraform validate passes
- [x] Installation order verified: Claude before dotfiles

## Impact
- **Eliminates warning messages** during cloud-init execution
- **Improves user experience** by reducing log noise
- **Maintains functionality** - Claude CLI still gets installed correctly
- **Better installation order** - tools available when needed

## Expected Result
After this fix, the dotfiles install.sh script will find the Claude binary pre-installed and won't generate the "binary not found" warnings.

Fixes #307

🤖 Generated with Claude Code