### PR TITLE
Fix var_kubeconfig parameter validation in cloud-init (#313)

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -542,13 +542,18 @@ runcmd:
       fi
     fi
   - |
-    mkdir -p /root/.kube/
-    echo "$${var_kubeconfig}" | base64 -d > /root/.kube/config
-    chmod 400 /root/.kube/config
-    chmod 500 /root/.kube/
-    echo 'export KUBECONFIG=$HOME/.kube/config' >> /root/.bashrc
-    echo 'export KUBECONFIG=$HOME/.kube/config' >> /root/.profile
-    echo 'export KUBECONFIG=$HOME/.kube/config' >> /root/.zshrc
+    if [ -n "$${var_kubeconfig}" ]; then
+      mkdir -p /root/.kube/
+      echo "$${var_kubeconfig}" | base64 -d > /root/.kube/config
+      chmod 400 /root/.kube/config
+      chmod 500 /root/.kube/
+      echo 'export KUBECONFIG=$HOME/.kube/config' >> /root/.bashrc
+      echo 'export KUBECONFIG=$HOME/.kube/config' >> /root/.profile
+      echo 'export KUBECONFIG=$HOME/.kube/config' >> /root/.zshrc
+      echo "[INFO] Kubeconfig configured successfully"
+    else
+      echo "[WARN] Kubeconfig not provided, skipping kubectl setup"
+    fi
   - useradd -D -s "$(which zsh)"
   - sed -i -E 's|^#?DSHELL=.*|DSHELL=/usr/bin/zsh|' /etc/adduser.conf
   - |


### PR DESCRIPTION
## Summary
Fixes critical issue where cloud-init scripts_user module fails with "var_kubeconfig: parameter not set" error during CLOUDSHELL VM deployment.

## Problem Description
- Cloud-init fails at line 121 of runcmd script when `var_kubeconfig` is empty
- Occurs when `var.cloudshell` is false or AKS cluster is unavailable
- `local.kubeconfig` becomes empty string `""` causing shell parameter error
- Results in incomplete CLOUDSHELL VM initialization

## Solution Implemented
- Added conditional validation `[ -n "${var_kubeconfig}" ]` before using the variable
- Skip kubectl setup gracefully when kubeconfig is not provided  
- Added informative logging for both success and skip scenarios
- Ensures cloud-init completes successfully regardless of kubeconfig availability

## Changes Made
- Modified `cloud-init/CLOUDSHELL.conf` line 545-556
- Wrapped kubeconfig setup in proper conditional block
- Added error handling and logging messages

## Testing
- ✅ `terraform fmt` - No formatting issues
- ✅ `terraform init -backend=false` - Successful initialization
- ✅ `terraform validate` - Configuration is valid

## Impact
- **CRITICAL** issue resolution - prevents cloud-init failure
- Maintains backward compatibility when kubeconfig is available
- Graceful degradation when kubeconfig is unavailable
- No functional impact on existing deployments with valid kubeconfig

## Related Issues
Closes #313

🤖 Generated with [Claude Code](https://claude.ai/code)