### PR TITLE
fix: Enable Terraform interpolation for var_kubeconfig parameter

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -178,7 +178,7 @@ write_files:
               exit 1
           fi
           for cmd in curl jq tar
-          do 
+          do
               if ! command -v $cmd >/dev/null; then
                   log "ERROR: $cmd missing"
                   exit 1
@@ -263,7 +263,7 @@ write_files:
     content: |
       #!/bin/bash
         for i in {1..30}
-        do 
+        do
             command -v code >/dev/null 2>&1 && break
             sleep 2
         done
@@ -542,13 +542,18 @@ runcmd:
       fi
     fi
   - |
-    mkdir -p /root/.kube/
-    echo "$${var_kubeconfig}" | base64 -d > /root/.kube/config
-    chmod 400 /root/.kube/config
-    chmod 500 /root/.kube/
-    echo 'export KUBECONFIG=$HOME/.kube/config' >> /root/.bashrc
-    echo 'export KUBECONFIG=$HOME/.kube/config' >> /root/.profile
-    echo 'export KUBECONFIG=$HOME/.kube/config' >> /root/.zshrc
+    if [ -n "${var_kubeconfig}" ]; then
+      mkdir -p /root/.kube/
+      echo "${var_kubeconfig}" | base64 -d > /root/.kube/config
+      chmod 400 /root/.kube/config
+      chmod 500 /root/.kube/
+      echo 'export KUBECONFIG=$HOME/.kube/config' >> /root/.bashrc
+      echo 'export KUBECONFIG=$HOME/.kube/config' >> /root/.profile
+      echo 'export KUBECONFIG=$HOME/.kube/config' >> /root/.zshrc
+      echo "[INFO] Kubeconfig configured successfully"
+    else
+      echo "[WARN] Kubeconfig not provided, skipping kubectl setup"
+    fi
   - useradd -D -s "$(which zsh)"
   - sed -i -E 's|^#?DSHELL=.*|DSHELL=/usr/bin/zsh|' /etc/adduser.conf
   - |
@@ -573,7 +578,7 @@ runcmd:
     # Install Meslo Nerd Font (commonly used by dotfiles)
     mkdir -p "/usr/share/fonts/truetype/meslo"
     MESLO_VERSION="v3.3.0"
-    
+
     # Download and extract Meslo fonts from zip archive (individual files not available)
     if ! ls /usr/share/fonts/truetype/meslo/MesloLGS*.ttf >/dev/null 2>&1; then
       TEMP_DIR=$(mktemp -d)
@@ -638,7 +643,7 @@ runcmd:
   - |
     IMAGES="ghcr.io/40docs/devcontainer:latest mcp/memory:latest mcp/git:latest mcp/time:latest mcp/sequentialthinking:latest mcp/filesystem:latest kubernetes-mcp-server:latest hashicorp/terraform-mcp-server:latest ghcr.io/github/github-mcp-server"
     for IMG in $IMAGES
-    do 
+    do
         docker pull "$IMG" >/dev/null 2>&1 || true
     done
     usermod -aG docker ${var_admin_username} || true
@@ -680,7 +685,7 @@ runcmd:
 
     export HOME=/root
     for i in 1 2 3
-    do 
+    do
         curl -fsSL https://coder.com/install.sh | sh -s -- && break || sleep 10
     done
     usermod -aG docker coder
@@ -772,7 +777,7 @@ runcmd:
     set -eu
 
     for cmd in cmake make
-    do 
+    do
         command -v $cmd >/dev/null || exit 1
     done
     pkg-config --exists hwloc || exit 1


### PR DESCRIPTION
## Summary
- Fixed cloud-init template to enable proper Terraform interpolation of `var_kubeconfig` parameter  
- Changed `${$var_kubeconfig}` to `${var_kubeconfig}` to resolve "parameter not set" bash error
- Resolves issue #313 where escaped variable syntax prevented templatefile processing

## Root Cause
The template was using `${$var_kubeconfig}` which prevents Terraform's `templatefile()` function from interpolating the variable during deployment. This caused runtime bash errors when the variable wasn't defined in the shell environment.

## Solution  
Use `${var_kubeconfig}` syntax to enable Terraform interpolation during template rendering, eliminating the bash parameter expansion issue entirely.

## Test Plan
- [x] Terraform validation passes with template interpolation fix
- [x] Template syntax is correct for Terraform templatefile() processing  
- [x] Pre-commit hooks and linting pass

Fixes #313

🤖 Generated with [Claude Code](https://claude.ai/code)