### PR TITLE
Fix cloud-init YAML parsing errors by replacing heredoc with printf

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -181,12 +181,12 @@ write_files:
 
           for f in .bashrc .profile; do
               if ! grep -q 'NVM_DIR=/usr/local/nvm' /home/ubuntu/$f; then
-                  cat >> /home/ubuntu/$f << 'NVMEOF'
-export PATH="$HOME/.local/bin:/usr/local/bin:$PATH"
-export NVM_DIR=/usr/local/nvm
-[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
-export PATH="/usr/local/lib/node_modules/.bin:$PATH"
-NVMEOF
+                  printf '%s\n' \
+                    'export PATH="$HOME/.local/bin:/usr/local/bin:$PATH"' \
+                    'export NVM_DIR=/usr/local/nvm' \
+                    '[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"' \
+                    'export PATH="/usr/local/lib/node_modules/.bin:$PATH"' \
+                    >> /home/ubuntu/$f
               fi
           done
 


### PR DESCRIPTION
## Summary
- Replaced heredoc syntax with printf statements to avoid YAML parsing errors
- Fixes the cloud-init warning messages seen in serial console logs

## Problem
Cloud-init was still showing YAML parsing errors in the serial console:
```
Failed loading yaml blob. Invalid format at line 237 column 1: "while scanning a simple key
  in "<unicode string>", line 237, column 1:
    export PATH="$HOME/.local/bin:/u ...
```

## Solution  
Replaced the `cat << 'NVMEOF'` heredoc approach with `printf '%s\n'` statements to write the shell environment variables. This avoids any YAML interpretation issues while maintaining the same functionality.

## Testing
- [x] Terraform fmt passes
- [x] Terraform validate passes
- [x] Printf approach is POSIX-compliant and compatible with sh/bash

## Impact
This change will eliminate the cloud-init YAML parsing warnings and ensure proper environment variable setup for the GitHub runner on the cloudshell VM.

🤖 Generated with [Claude Code](https://claude.ai/code)