### PR TITLE
Fix SSH host key management for cloudshell VM

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -54,6 +54,7 @@ mounts:
   - ["LABEL=ollamafs", "/root/.ollama", "ext4", "defaults,nofail", "0", "2"]
 
 ssh_deletekeys: false
+ssh_genkeytypes: []  # Prevent cloud-init from generating new SSH host keys
 ssh_keys:
   rsa_private: |
     ${indent(4, var_ssh_host_rsa_private)}


### PR DESCRIPTION
## Summary
- Added `ssh_genkeytypes: []` to prevent cloud-init from generating new SSH host keys
- Ensures Terraform-managed keys are the only keys used

## Problem
Cloud-init was generating new SSH host keys on every VM deployment despite having Terraform-managed keys provided via the templatefile. This was evident from the console logs showing:
```
Generating public/private rsa key pair
```

## Solution
Added the `ssh_genkeytypes: []` directive to explicitly tell cloud-init not to generate any SSH host key types. Combined with the existing `ssh_deletekeys: false` and the `ssh_keys` section containing Terraform-managed keys, this ensures:
1. No new keys are generated by cloud-init
2. Existing keys (from Terraform) are preserved
3. SSH host keys remain consistent across VM recreations

## Testing
- [x] Terraform fmt passes
- [x] Terraform validate passes
- [x] Cloud-init configuration syntax is valid

## Impact
This ensures SSH host key persistence across VM deployments, preventing SSH host key verification warnings when reconnecting to the cloudshell VM after redeployments.

🤖 Generated with [Claude Code](https://claude.ai/code)