### PR TITLE
Fix: Remove exec from ansible-galaxy to prevent cloud-init termination

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -598,7 +598,7 @@ runcmd:
     unzip -q /tmp/awscliv2.zip -d /tmp
     /tmp/aws/install
     rm -rf /tmp/aws /tmp/awscliv2.zip
-  - exec ansible-galaxy collection install fortinet.console fortinet.fortiadc fortinet.fortianalyzer fortinet.fortiflexvm fortinet.fortimanager fortinet.fortios fortinet.fortiswitch fortinet.fortiweb </dev/stdin >/dev/stdout 2>/dev/stderr
+  - ansible-galaxy collection install fortinet.console fortinet.fortiadc fortinet.fortianalyzer fortinet.fortiflexvm fortinet.fortimanager fortinet.fortios fortinet.fortiswitch fortinet.fortiweb || true
   - |
     export HOME=/root && bash /root/npm-install.sh || true
   - |


### PR DESCRIPTION
## Summary
- Fixed cloud-init runcmd script early termination at line 198 of 366
- Removed `exec` command that was replacing the shell process with ansible-galaxy
- This allows the remaining ~168 lines of cloud-init configuration to execute properly

## Problem
The `exec` command in the ansible-galaxy line was causing the shell to be replaced by the ansible-galaxy process. When ansible-galaxy completed, the entire runcmd script terminated, preventing critical configuration steps from running.

## Impact of the Bug
The following configurations were never applied:
- npm package installations (line 199+)
- Docker image pulls and configurations
- **/etc/skel population** with user dotfiles and configurations (line 348+) 
- GitHub runner setup (line 358+)
- VS Code tunnel configuration
- Firmware updates and conditional reboot

## Solution
Changed from:
```bash
exec ansible-galaxy collection install ... </dev/stdin >/dev/stdout 2>/dev/stderr
```
To:
```bash
ansible-galaxy collection install ... || true
```

## Testing
- [x] Verified the issue by examining cloud-init logs showing early termination
- [x] Confirmed /etc/skel was empty due to script not reaching line 348
- [x] Manually executed remaining commands to verify they work correctly
- [ ] Will validate full cloud-init execution on next VM deployment

## Files Changed
- `cloud-init/CLOUDSHELL.conf` line 601

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
