### PR TITLE
Fix: Resolve ansible-galaxy blocking IO error in cloud-init

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -598,7 +598,10 @@ runcmd:
     unzip -q /tmp/awscliv2.zip -d /tmp
     /tmp/aws/install
     rm -rf /tmp/aws /tmp/awscliv2.zip
-  - ansible-galaxy collection install fortinet.console fortinet.fortiadc fortinet.fortianalyzer fortinet.fortiflexvm fortinet.fortimanager fortinet.fortios fortinet.fortiswitch fortinet.fortiweb || true
+  - |
+    # Execute ansible-galaxy with explicit bash to avoid dash shell issues
+    # Redirect stdin from /dev/null to prevent blocking IO errors
+    bash -c 'ansible-galaxy collection install fortinet.console fortinet.fortiadc fortinet.fortianalyzer fortinet.fortiflexvm fortinet.fortimanager fortinet.fortios fortinet.fortiswitch fortinet.fortiweb < /dev/null' || true
   - |
     export HOME=/root && bash /root/npm-install.sh || true
   - |


### PR DESCRIPTION
## Summary
- Fixed ansible-galaxy command execution causing blocking IO errors during cloud-init
- Wrapped command in explicit bash shell with stdin redirection to prevent interactive mode issues
- Added explanatory comments for future maintenance

## Problem
The `ansible-galaxy collection install` command was failing with "Ansible blocking IO error: Non-blocking file handles detected" during cloud-init execution. This was caused by the command running under dash shell (cloud-init's default for runcmd) which doesn't handle stdin/stdout properly for potentially interactive commands.

## Solution
- Execute ansible-galaxy using explicit `bash -c` wrapper
- Redirect stdin from `/dev/null` to prevent blocking IO
- Maintain error handling with `|| true` to prevent cloud-init failure

## Testing
- [x] Terraform formatting passes
- [x] Cloud-init syntax is valid
- [ ] Tested on new CLOUDSHELL VM deployment

🤖 Generated with [Claude Code](https://claude.ai/code)