### PR TITLE
Fix: Remove ssh_genkeytypes to resolve cloud-init validation warning

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -54,7 +54,6 @@ mounts:
   - ["LABEL=ollamafs", "/root/.ollama", "ext4", "defaults,nofail", "0", "2"]
 
 ssh_deletekeys: false
-ssh_genkeytypes: []  # Prevent cloud-init from generating new SSH host keys
 ssh_keys:
   rsa_private: |
     ${indent(4, var_ssh_host_rsa_private)}


### PR DESCRIPTION
## Summary
- Removed the empty `ssh_genkeytypes: []` directive from CLOUDSHELL.conf
- This eliminates the cloud-init schema validation warning

## Problem
Cloud-init was reporting a schema validation error:
```
Error: Cloud config schema errors: ssh_genkeytypes: [] should be non-empty
```

## Solution
The `ssh_genkeytypes: []` directive is redundant since:
1. `ssh_deletekeys: false` already preserves existing keys
2. SSH keys are explicitly provided via the `ssh_keys` section
3. The empty array was correctly preventing key generation but triggering a false-positive validation warning

## Testing
- [x] Cloud-init syntax validates without errors
- [x] SSH keys remain consistent (no new keys generated)
- [x] Schema validation warning is eliminated

## Related Issues
- Fixes #351
- Addresses residual validation warning from PR #336

🤖 Generated with [Claude Code](https://claude.ai/code)