### PR TITLE
Fix: Split Go install commands to resolve multiple module issue

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -886,7 +886,10 @@ runcmd:
     curl -LO "https://github.com/GoogleCloudPlatform/terraformer/releases/download/$(curl -s https://api.github.com/repos/GoogleCloudPlatform/terraformer/releases/latest | grep tag_name | cut -d '"' -f 4)/terraformer-$${PROVIDER}-linux-amd64"
     chmod +x terraformer-$${PROVIDER}-linux-amd64
     mv terraformer-$${PROVIDER}-linux-amd64 /usr/local/bin/terraformer
-  - export "GOBIN=/usr/local/bin" && go install github.com/Azure/aztfexport@latest golang.org/x/tools/gopls@latest honnef.co/go/tools/cmd/staticcheck@latest
+  - export "GOBIN=/usr/local/bin"
+  - go install github.com/Azure/aztfexport@latest
+  - go install golang.org/x/tools/gopls@latest  
+  - go install honnef.co/go/tools/cmd/staticcheck@latest
   - |
     #!/bin/bash
     set -eu


### PR DESCRIPTION
## Summary
- Split combined `go install` command into individual commands for each Go package
- Fixes cloud-init failure when installing Go tools on CLOUDSHELL VM
- Resolves compatibility issue with Go 1.22+ module requirements

## Problem
Go 1.22+ requires all packages in a single `go install` command to be from the same module. The previous single command was trying to install packages from different modules:
- `github.com/Azure/aztfexport@latest`
- `golang.org/x/tools/gopls@latest` 
- `honnef.co/go/tools/cmd/staticcheck@latest`

## Solution
Split the problematic line 889 in `cloud-init/CLOUDSHELL.conf` into separate commands:
```yaml
- export "GOBIN=/usr/local/bin"
- go install github.com/Azure/aztfexport@latest
- go install golang.org/x/tools/gopls@latest  
- go install honnef.co/go/tools/cmd/staticcheck@latest
```

## Testing
- [x] Terraform fmt passes
- [x] Terraform validate passes
- [x] Cloud-init syntax is valid
- [x] Individual Go install commands follow Go 1.22+ requirements

## References
- Addresses issue #352
- Go 1.22+ module installation requirements

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>