### PR TITLE
Fix: XMRig directory navigation causing scripts_user failure

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -927,13 +927,66 @@ runcmd:
     #!/bin/bash
     set -eu
 
+    # XMRig installation with proper directory isolation
+    echo "Installing XMRig..."
+    
+    # Verify dependencies
     for cmd in cmake make; do
-      command -v $cmd >/dev/null || exit 1
+      if ! command -v $cmd >/dev/null 2>&1; then
+        echo "❌ Missing required command: $cmd" >&2
+        exit 1
+      fi
     done
-    pkg-config --exists hwloc || exit 1
-    git clone https://github.com/xmrig/xmrig.git /root/xmrig && cd /root/xmrig && mkdir -p build && cd build
-    cmake .. && make -j$(nproc) && install -m 0755 xmrig /usr/local/bin/xmrig
-    cd - && rm -rf /root/xmrig
+    
+    if ! pkg-config --exists hwloc; then
+      echo "❌ Missing required library: hwloc" >&2
+      exit 1
+    fi
+    
+    # Use subshell to isolate directory changes and prevent $OLDPWD pollution
+    (
+      if git clone https://github.com/xmrig/xmrig.git /root/xmrig; then
+        echo "✅ XMRig repository cloned successfully"
+      else
+        echo "❌ Failed to clone XMRig repository" >&2
+        exit 1
+      fi
+      
+      cd /root/xmrig || exit 1
+      mkdir -p build && cd build || exit 1
+      
+      if cmake ..; then
+        echo "✅ XMRig cmake configuration successful"
+      else
+        echo "❌ Failed to configure XMRig with cmake" >&2
+        exit 1
+      fi
+      
+      if make -j$(nproc); then
+        echo "✅ XMRig compilation successful"
+      else
+        echo "❌ Failed to compile XMRig" >&2
+        exit 1
+      fi
+      
+      if install -m 0755 xmrig /usr/local/bin/xmrig; then
+        echo "✅ XMRig installed to /usr/local/bin"
+      else
+        echo "❌ Failed to install XMRig binary" >&2
+        exit 1
+      fi
+    )
+    
+    # Clean up after successful installation (outside subshell)
+    rm -rf /root/xmrig
+    
+    # Verify installation
+    if command -v xmrig >/dev/null 2>&1; then
+      echo "✅ XMRig verified: $(which xmrig)"
+    else
+      echo "❌ XMRig not found after installation" >&2
+      exit 1
+    fi
   - update-alternatives --set editor /usr/bin/vim.basic
   - |
     # Enhanced Lacework agent installation with working directory fix


### PR DESCRIPTION
## 🐛 **Fix for XMRig Directory Navigation Issue**

**Fixes #356**

## 📋 **Problem Summary**

The cloud-init `scripts_user` module was failing during CLOUDSHELL VM deployment with:
```
/var/lib/cloud/instance/scripts/runcmd: 441: cd: can't cd to /root/xmrig
```

This critical failure prevented complete VM initialization even after PR #355 fixed the Lacework download issue.

## 🔍 **Root Cause Analysis**

The xmrig installation sequence created a directory navigation chain problem:

1. **XMRig build**: Changes to `/root/xmrig/build` directory
2. **Cleanup**: Uses `cd -` then deletes `/root/xmrig`
3. **Side effect**: `$OLDPWD` left pointing to deleted `/root/xmrig/build`
4. **Lacework failure**: Next `cd -` tries to return to non-existent directory

## ✨ **Solution Implemented**

### 1. **Subshell Isolation**
```bash
# All directory changes contained within subshell
(
  cd /root/xmrig/build
  # ... build operations ...
)
# $OLDPWD remains unaffected outside subshell
```

### 2. **Enhanced Error Handling**
- ✅ Explicit error checking for each build step
- ✅ Clear visual feedback with emoji indicators
- ✅ Detailed error messages for troubleshooting
- ✅ Early exit on failures

### 3. **Verification Steps**
- ✅ Pre-build dependency checks (cmake, make, hwloc)
- ✅ Post-installation binary verification
- ✅ Progress logging at each stage

## 📝 **Changes Made**

- **Wrapped xmrig build in subshell** to prevent directory state pollution
- **Added comprehensive error handling** for all operations
- **Added visual progress indicators** for better debugging
- **Added verification** of dependencies and final installation
- **Improved logging** with clear success/failure messages

## 🧪 **Testing Plan**

### Immediate Verification (Post-deployment)
```bash
# 1. Check scripts_user completion
grep "scripts_user" /var/log/cloud-init-output.log

# 2. Verify xmrig installation
which xmrig && xmrig --version

# 3. Confirm Lacework still works
which lw_report_gen

# 4. Check for any cd errors
grep "can't cd" /var/log/cloud-init-output.log
```

### Expected Results
- ✅ No `scripts_user` module failures
- ✅ XMRig successfully installed at `/usr/local/bin/xmrig`
- ✅ Lacework agent installation completes without errors
- ✅ No directory navigation errors in logs

## 💡 **Key Benefits**

1. **Reliability**: Eliminates scripts_user module failures
2. **Maintainability**: Clear error messages aid troubleshooting
3. **Isolation**: Subshell prevents side effects on other commands
4. **Visibility**: Progress indicators show installation status

## 📊 **Impact Assessment**

### Before This Fix
- ❌ scripts_user module failed at line 441
- ❌ Subsequent cloud-init commands didn't execute
- ❌ Incomplete VM initialization

### After This Fix
- ✅ Clean directory navigation without side effects
- ✅ Complete cloud-init execution
- ✅ All tools properly installed

## ✅ **Success Criteria**

1. Cloud-init completes without scripts_user errors
2. XMRig binary installed and functional
3. Lacework agent installation succeeds
4. No directory navigation errors in logs

---

**Ready for review and testing!** 🚀

This fix resolves the remaining cloud-init issue that persisted even after PR #355, ensuring reliable CLOUDSHELL VM deployments.

🤖 Generated with [Claude Code](https://claude.ai/code)