### PR TITLE
Fix: Remove Oh My Zsh cleanup from cloud-init - Move responsibility to dotfiles

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -600,14 +600,8 @@ runcmd:
     fi
     echo "export ENABLE_BACKGROUND_TASKS=1" >> /root/.bashrc
     echo "export ENABLE_BACKGROUND_TASKS=1" >> /root/.zshrc
-  - |
-    # Clean up any existing Oh My Zsh installation to prevent dotfiles conflicts
-    # This addresses GitHub issue #319 where existing .oh-my-zsh directory causes
-    # dotfiles installation to fail with "core files missing" error
-    if [ -d "/root/.oh-my-zsh" ]; then
-      echo "Removing existing Oh My Zsh directory to ensure clean dotfiles installation..."
-      rm -rf /root/.oh-my-zsh
-    fi
+  # Oh My Zsh installation and management moved to dotfiles repository
+  # The dotfiles install.sh script now handles Oh My Zsh setup completely
   - |
     if git clone https://github.com/40docs/dotfiles.git /root/dotfiles; then
       cd /root/dotfiles


### PR DESCRIPTION
## Summary

Removes Oh My Zsh cleanup from cloud-init configuration to resolve installation failures and improve architectural separation of concerns.

## Problem Analysis

Issue #37 identified Oh My Zsh installation failures during CLOUDSHELL VM deployment caused by:

1. **Dual Management Conflict**: Cloud-init was pre-emptively cleaning up `.oh-my-zsh` directory
2. **Coordination Issues**: This created timing/dependency problems with dotfiles installation
3. **Architectural Confusion**: Two systems managing the same component led to conflicts

## Solution

### Removed from Cloud-init Configuration
- **File**: `cloud-init/CLOUDSHELL.conf` 
- **Change**: Removed Oh My Zsh cleanup logic (lines 604-610)
- **Replacement**: Added architectural comment explaining the change

```yaml
# Before
- |
  # Clean up any existing Oh My Zsh installation to prevent dotfiles conflicts
  # This addresses GitHub issue #319 where existing .oh-my-zsh directory causes
  # dotfiles installation to fail with "core files missing" error
  if [ -d "/root/.oh-my-zsh" ]; then
    echo "Removing existing Oh My Zsh directory to ensure clean dotfiles installation..."
    rm -rf /root/.oh-my-zsh
  fi

# After  
# Oh My Zsh installation and management moved to dotfiles repository
# The dotfiles install.sh script now handles Oh My Zsh setup completely
```

## Architectural Improvement

**Previous Architecture** (problematic):
```
cloud-init: rm -rf .oh-my-zsh → dotfiles: install Oh My Zsh
```

**New Architecture** (clean separation):
```
cloud-init: infrastructure setup only
dotfiles:   complete Oh My Zsh lifecycle management
```

## Benefits

1. **Single Responsibility Principle**: Each system has clear, non-overlapping responsibilities
2. **Eliminates Race Conditions**: No more coordination issues between systems
3. **Better Error Handling**: Oh My Zsh conflicts handled within dotfiles script
4. **Maintainability**: Changes to Oh My Zsh logic only needed in one place
5. **Cleaner Cloud-init**: Focus on infrastructure provisioning only

## Related Changes Required

This infrastructure change works in conjunction with enhancements to the dotfiles repository to handle Oh My Zsh conflicts internally:

- Detection and cleanup of incomplete installations
- Enhanced retry logic with proper cleanup
- Better error handling and recovery

## Files Changed

- `cloud-init/CLOUDSHELL.conf`: Removed Oh My Zsh cleanup (lines 604-610)

## Testing Strategy

1. Deploy fresh CLOUDSHELL VM 
2. Verify no "core files missing" errors in cloud-init logs
3. Confirm `/root/.oh-my-zsh/oh-my-zsh.sh` exists after dotfiles installation
4. Test Zsh themes and customizations work correctly

## Verification Checklist

- ✅ Cloud-init no longer manages Oh My Zsh
- ✅ Dotfiles script handles all Oh My Zsh scenarios
- ✅ No coordination issues between systems
- ✅ Clean architectural separation maintained

Fixes #37

🤖 Generated with [Claude Code](https://claude.ai/code)