### PR TITLE
fix: Escape bash parameter expansion in cloud-init template

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -173,7 +173,7 @@ write_files:
           echo "Runner Configuration:"
           echo "  Organization URL: $ORG_URL"
           echo "  Runner Name: $RUNNER_NAME"
-          echo "  Runner Group: ${RUNNER_GROUP:-default}"
+          echo "  Runner Group: $${RUNNER_GROUP:-default}"
           echo "  Runner Labels: $RUNNER_LABELS"
 
           if [ -z "$GITHUB_TOKEN" ]


### PR DESCRIPTION
## Summary
Fixes Terraform template interpolation error introduced in PR #377.

## Problem
The cloud-init template contained an unescaped bash parameter expansion `${RUNNER_GROUP:-default}` which Terraform tried to interpret as a template variable, causing the infrastructure workflow to fail.

## Solution  
Properly escaped the bash syntax by adding an extra `$` to make it `$${RUNNER_GROUP:-default}`, which tells Terraform to treat it as literal text rather than a template interpolation.

## Error Message Fixed
```
Call to function "templatefile" failed:
./cloud-init/CLOUDSHELL.conf:176,47-48: Extra characters after interpolation
expression; Template interpolation doesn't expect a colon at this location.
```

## Test Plan
- [x] Terraform formatting validated
- [ ] Infrastructure workflow will validate on merge

🤖 Generated with [Claude Code](https://claude.ai/code)