### PR TITLE
Fix GitHub Actions Runner Queue Issue #379

### DIFF
--- a/.github/workflows/test-uppercase.yml
+++ b/.github/workflows/test-uppercase.yml
@@ -1,0 +1,17 @@
+name: Test UPPERCASE CLOUDSHELL
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test-uppercase:
+    name: "Test CLOUDSHELL (uppercase)"
+    runs-on: CLOUDSHELL
+    timeout-minutes: 2
+    
+    steps:
+      - name: "Test runner"
+        run: |
+          echo "✅ CLOUDSHELL (uppercase) runner is working!"
+          echo "Hostname: $(hostname)"
+          echo "Labels that matched: CLOUDSHELL"

--- a/variables.tf
+++ b/variables.tf
@@ -16,7 +16,7 @@ variable "runner_group" {
 
 variable "runner_labels" {
   type        = string
-  default     = "self-hosted,linux,x64,build,ubuntu"
+  default     = "CLOUDSHELL,cloudshell,self-hosted,linux"
   description = "Comma-separated labels to attach to the runner"
 }
 


### PR DESCRIPTION
## Summary

This PR fixes the GitHub Actions runner queue issue where jobs remain in 'queued' status and never execute on the CLOUDSHELL runner.

## Root Cause Analysis

The issue was identified as a mismatch between the runner labels configuration:
- The `runner_labels` variable in `variables.tf` had default value `self-hosted,linux,x64,build,ubuntu` 
- But the cloud-init script expects labels including `CLOUDSHELL` and `cloudshell`
- This caused jobs targeting the CLOUDSHELL runner to remain in queue

## Changes Made

1. **Fixed `variables.tf`**: Updated `runner_labels` default from `self-hosted,linux,x64,build,ubuntu` to `CLOUDSHELL,cloudshell,self-hosted,linux`

2. **Added test workflow**: `test-uppercase.yml` to verify the `CLOUDSHELL` (uppercase) label works correctly

## Testing Plan

- [x] Verified runner service is active and listening for jobs
- [x] Confirmed runner shows in GitHub API (though as 'offline')
- [x] Identified label mismatch as root cause
- [ ] Test uppercase CLOUDSHELL label workflow
- [ ] Test existing runner-test.yml workflow
- [ ] Verify both CLOUDSHELL and cloudshell labels work

## Expected Outcome

After this fix:
- Runner should show as 'online' in GitHub
- Jobs targeting CLOUDSHELL labels should execute immediately
- Both uppercase `CLOUDSHELL` and lowercase `cloudshell` labels should work

## Related Issues

Fixes #379

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>