### PR TITLE
Fix Terraform templatefile bash parameter substitution errors

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -273,14 +273,14 @@ write_files:
   - path: /etc/ssh/sshd_config.d/custom.conf
     content: |
       # SSH Security Hardening Configuration
-      
+
       # Basic PAM and authentication settings
       UsePAM yes
       KbdInteractiveAuthentication yes
       PrintMotd no
       PrintLastLog no
       UseDNS no
-      
+
       # Security hardening measures
       Protocol 2
       PermitRootLogin yes
@@ -288,19 +288,19 @@ write_files:
       MaxSessions 10
       MaxStartups 10:30:60
       LoginGraceTime 60
-      
+
       # Rate limiting and connection controls
       ClientAliveInterval 300
       ClientAliveCountMax 2
       TCPKeepAlive yes
-      
+
       # Disable unused authentication methods (but keep keyboard-interactive for authd)
       PubkeyAuthentication yes
       AuthenticationMethods "keyboard-interactive" "publickey"
       PasswordAuthentication no
       PermitEmptyPasswords no
       ChallengeResponseAuthentication no
-      
+
       # Disable unused features
       X11Forwarding no
       X11UseLocalhost yes
@@ -308,7 +308,7 @@ write_files:
       AllowAgentForwarding yes
       AllowTcpForwarding yes
       GatewayPorts no
-      
+
       # Restrict user access
       DenyUsers guest
       DenyUsers nobody
@@ -316,11 +316,11 @@ write_files:
       DenyUsers Admin
       DenyUsers admin
       DenyUsers user
-      
+
       # Logging and monitoring
       LogLevel VERBOSE
       SyslogFacility AUTH
-      
+
       # Banner and version information
       Banner /etc/ssh/banner
       VersionAddendum none
@@ -345,7 +345,7 @@ write_files:
     content: |
       # Custom fail2ban configuration for CLOUDSHELL VM
       # Enhanced SSH protection against brute force attacks
-      
+
       [DEFAULT]
       # Global settings
       ignoreip = 127.0.0.1/8 ::1 10.0.0.0/8 192.168.0.0/16 172.16.0.0/12
@@ -361,11 +361,11 @@ write_files:
       chain = INPUT
       port = 0:65535
       fail2ban_agent = Fail2Ban/%(fail2ban_version)s
-      
+
       # Enhanced logging
       loglevel = INFO
       logtarget = /var/log/fail2ban.log
-      
+
       [sshd]
       enabled = true
       port = ssh
@@ -375,7 +375,7 @@ write_files:
       findtime = 300
       bantime = 3600
       action = %(action_mwl)s
-      
+
       [sshd-aggressive]
       enabled = true
       port = ssh
@@ -385,7 +385,7 @@ write_files:
       findtime = 300
       bantime = 86400
       action = %(action_mwl)s
-      
+
       [recidive]
       enabled = true
       logpath = /var/log/fail2ban.log
@@ -400,10 +400,10 @@ write_files:
       # Aggressive SSH filter for enhanced protection
       [INCLUDES]
       before = common.conf
-      
+
       [Definition]
       _daemon = sshd
-      
+
       failregex = ^%(__prefix_line)s(?:error: PAM: )?[aA]uthentication (?:failure|error|failed) for .* from <HOST>( via \S+)?\s*$
                   ^%(__prefix_line)s(?:error: )?Received disconnect from <HOST>: 3: .*: Auth fail$
                   ^%(__prefix_line)sUser .+ from <HOST> not allowed because not listed in AllowUsers\s*$
@@ -416,9 +416,9 @@ write_files:
                   ^%(__prefix_line)sDisconnected from (authenticating |invalid )?user .+ <HOST> port \d+ \[preauth\]\s*$
                   ^%(__prefix_line)sInvalid user .+ from <HOST> port \d+$
                   ^%(__prefix_line)sUser .+ from <HOST> not allowed because .+$
-      
+
       ignoreregex =
-      
+
       journalmatch = _SYSTEMD_UNIT=sshd.service + _COMM=sshd
   - path: /etc/fail2ban/action.d/cloudshell-notify.conf
     permissions: '0644'
@@ -427,24 +427,24 @@ write_files:
       # Custom notification action for CLOUDSHELL security events
       [INCLUDES]
       before = common.conf
-      
+
       [Definition]
       actionstart = echo "[$(date)] Fail2ban started" >> /var/log/security-events.log
                    logger -p auth.info "Fail2ban jail <name> started"
-      
+
       actionstop = echo "[$(date)] Fail2ban stopped" >> /var/log/security-events.log
                   logger -p auth.info "Fail2ban jail <name> stopped"
-      
+
       actioncheck =
-      
+
       actionban = echo "[$(date)] SECURITY ALERT: IP <ip> banned by jail <name> after <failures> attempts. Country: $(geoiplookup <ip> 2>/dev/null || echo 'Unknown')" >> /var/log/security-events.log
                  logger -p auth.warning "SECURITY ALERT: IP <ip> banned by fail2ban jail <name>"
                  iptables -I f2b-<name> 1 -s <ip> -j DROP
-      
+
       actionunban = echo "[$(date)] IP <ip> unbanned from jail <name>" >> /var/log/security-events.log
                    logger -p auth.info "IP <ip> unbanned from fail2ban jail <name>"
                    iptables -D f2b-<name> -s <ip> -j DROP
-      
+
       [Init]
       name = default
   - path: /usr/local/bin/security-monitor.sh
@@ -454,57 +454,57 @@ write_files:
       #!/bin/bash
       # CLOUDSHELL Security Monitoring Script
       # Monitors SSH attacks and generates security reports
-      
+
       set -euo pipefail
-      
+
       SECURITY_LOG="/var/log/security-events.log"
       AUTH_LOG="/var/log/auth.log"
       REPORT_FILE="/var/log/security-report.log"
-      
+
       # Create logs if they don't exist
       touch "$SECURITY_LOG" "$REPORT_FILE"
-      
+
       # Function to generate security report
       generate_report() {
           local timeframe="$${1:-24 hours}"
           echo "=== CLOUDSHELL Security Report - $(date) ===" >> "$REPORT_FILE"
           echo "Analysis period: Last $timeframe" >> "$REPORT_FILE"
           echo >> "$REPORT_FILE"
-          
+
           # SSH attack statistics
           echo "SSH Attack Statistics:" >> "$REPORT_FILE"
           grep "Failed password" "$AUTH_LOG" | tail -1000 | awk '{print $1, $2, $3, $(NF-3)}' | sort | uniq -c | sort -nr | head -10 >> "$REPORT_FILE" 2>/dev/null || true
           echo >> "$REPORT_FILE"
-          
+
           # Most attacked usernames
           echo "Most Targeted Usernames:" >> "$REPORT_FILE"
           grep "Failed password\|Invalid user" "$AUTH_LOG" | tail -1000 | awk '{if(/Invalid user/) print $(NF-3); else if(/Failed password/) print $9}' | sort | uniq -c | sort -nr | head -10 >> "$REPORT_FILE" 2>/dev/null || true
           echo >> "$REPORT_FILE"
-          
+
           # Current fail2ban status
           echo "Fail2ban Status:" >> "$REPORT_FILE"
           fail2ban-client status 2>/dev/null >> "$REPORT_FILE" || echo "Fail2ban not running" >> "$REPORT_FILE"
           echo >> "$REPORT_FILE"
-          
+
           # Active bans
           echo "Currently Banned IPs:" >> "$REPORT_FILE"
           fail2ban-client status sshd 2>/dev/null | grep "Banned IP list" >> "$REPORT_FILE" || true
           echo "=== End Report ===" >> "$REPORT_FILE"
           echo >> "$REPORT_FILE"
       }
-      
+
       # Function to check for critical security events
       check_security_events() {
           # Count recent failed attempts (last hour)
           local recent_failures
           recent_failures=$(grep "$(date '+%Y-%m-%d %H')" "$AUTH_LOG" | grep -c "Failed password\|Invalid user" || echo "0")
-          
+
           if [ "$recent_failures" -gt 50 ]; then
               echo "[$(date)] CRITICAL: $recent_failures failed SSH attempts in the last hour!" >> "$SECURITY_LOG"
               logger -p auth.crit "CRITICAL SECURITY ALERT: $recent_failures failed SSH attempts in the last hour"
           fi
       }
-      
+
       # Function to update geographic information
       update_geoip() {
           if command -v geoiplookup >/dev/null 2>&1; then
@@ -514,7 +514,7 @@ write_files:
               apt-get update -qq && apt-get install -y geoip-bin geoip-database 2>/dev/null || true
           fi
       }
-      
+
       # Main execution
       case "$${1:-report}" in
           "report")
@@ -549,7 +549,7 @@ write_files:
       Description=CLOUDSHELL Security Monitor
       After=network.target fail2ban.service
       Wants=fail2ban.service
-      
+
       [Service]
       Type=simple
       ExecStart=/usr/local/bin/security-monitor.sh monitor
@@ -559,7 +559,7 @@ write_files:
       Group=root
       StandardOutput=journal
       StandardError=journal
-      
+
       [Install]
       WantedBy=multi-user.target
   - path: /etc/systemd/system/security-report.service
@@ -568,7 +568,7 @@ write_files:
     content: |
       [Unit]
       Description=CLOUDSHELL Security Report Generator
-      
+
       [Service]
       Type=oneshot
       ExecStart=/usr/local/bin/security-monitor.sh report
@@ -581,11 +581,11 @@ write_files:
       [Unit]
       Description=Generate security reports every 6 hours
       Requires=security-report.service
-      
+
       [Timer]
       OnBootSec=1h
       OnUnitActiveSec=6h
-      
+
       [Install]
       WantedBy=timers.target
   - path: /usr/local/bin/ssh-security-check.sh
@@ -595,34 +595,34 @@ write_files:
       #!/bin/bash
       # SSH Security Configuration Validator
       # Validates SSH hardening and security measures
-      
+
       set -euo pipefail
-      
+
       RED='\033[0;31m'
       GREEN='\033[0;32m'
       YELLOW='\033[1;33m'
       NC='\033[0m' # No Color
-      
+
       echo -e "$${GREEN}=== CLOUDSHELL SSH Security Check ===$${NC}"
       echo "Timestamp: $(date)"
       echo
-      
+
       # Check SSH configuration
       echo -e "$${YELLOW}SSH Configuration Security:$${NC}"
-      
+
       check_sshd_config() {
           local param="$1"
           local expected="$2"
           local actual
           actual=$(sshd -T 2>/dev/null | grep -i "^$param " | awk '{print $2}' || echo "not found")
-          
+
           if [[ "$actual" == "$expected" ]]; then
               echo -e "  ✅ $param: $actual"
           else
               echo -e "  ❌ $param: $actual (expected: $expected)"
           fi
       }
-      
+
       check_sshd_config "maxauthtries" "3"
       check_sshd_config "maxsessions" "10"
       check_sshd_config "loginfacetime" "60"
@@ -630,12 +630,12 @@ write_files:
       check_sshd_config "passwordauthentication" "no"
       check_sshd_config "permitemptypasswords" "no"
       check_sshd_config "x11forwarding" "no"
-      
+
       echo
       echo -e "$${YELLOW}Fail2ban Status:$${NC}"
       if systemctl is-active fail2ban >/dev/null 2>&1; then
           echo -e "  ✅ Fail2ban service: Active"
-          
+
           # Check jail statuses
           for jail in sshd sshd-aggressive recidive; do
               if fail2ban-client status "$jail" >/dev/null 2>&1; then
@@ -649,21 +649,21 @@ write_files:
       else
           echo -e "  ❌ Fail2ban service: Inactive"
       fi
-      
+
       echo
       echo -e "$${YELLOW}Recent Security Events:$${NC}"
-      
+
       # Recent attack attempts
       local recent_attacks
       recent_attacks=$(grep "$(date '+%Y-%m-%d')" /var/log/auth.log | grep -c "Failed password\|Invalid user" 2>/dev/null || echo "0")
       echo -e "  📊 Failed SSH attempts today: $recent_attacks"
-      
+
       # Top attacking IPs today
       echo -e "  🔍 Top attacking IPs today:"
       grep "$(date '+%Y-%m-%d')" /var/log/auth.log | grep "Failed password\|Invalid user" | awk '{print $(NF-3)}' | sort | uniq -c | sort -nr | head -5 | while read -r count ip; do
           echo -e "    $ip: $count attempts"
       done 2>/dev/null || echo "    No attacks detected today"
-      
+
       echo
       echo -e "$${YELLOW}Firewall Status:$${NC}"
       if command -v ufw >/dev/null 2>&1; then
@@ -675,7 +675,7 @@ write_files:
       else
           echo -e "  ❌ UFW firewall: Not installed"
       fi
-      
+
       echo
       echo -e "$${GREEN}Security check completed.$${NC}"
   - path: /root/prewarm-cache.sh
@@ -1297,17 +1297,17 @@ runcmd:
     echo "Installing Ollama..."
     if curl -fsSL https://ollama.com/install.sh | sh 2>&1 | grep -E "(Installing|Downloading|SUCCESS|complete)"; then
       systemctl start ollama.service && systemctl enable ollama.service
-      
+
       # Enhanced Ollama model download with retry logic and better error handling
       # Addresses GitHub issue #401: Ollama model download failures
-      
+
       echo "🤖 Starting enhanced Ollama model download process..."
-      
+
       # Function to wait for Ollama service to be fully ready
       wait_for_ollama_ready() {
         local max_attempts=30
         local attempt=1
-        
+
         echo "⏳ Waiting for Ollama service to be fully ready..."
         while [ $attempt -le $max_attempts ]; do
           if ollama list >/dev/null 2>&1; then
@@ -1318,24 +1318,24 @@ runcmd:
           sleep 5
           attempt=$((attempt + 1))
         done
-        
+
         echo "❌ ERROR: Ollama service failed to become ready after $max_attempts attempts"
         return 1
       }
-      
+
       # Function to download models with retry logic and progress monitoring
       download_ollama_model() {
         local model_name="$1"
         local max_retries=3
         local retry_delay=10
-        
+
         echo "📥 Starting download: $model_name"
-        
+
         for attempt in $(seq 1 $max_retries); do
           echo "🔄 Attempt $attempt/$max_retries for $model_name..."
-          
+
           # Download with timeout and detailed logging
-          if timeout 1800 ollama pull "$model_name" 2>&1 | tee "/tmp/ollama_${model_name//[:\/]/_}_attempt_${attempt}.log"; then
+          if timeout 1800 ollama pull "$model_name" 2>&1 | tee "/tmp/ollama_$${model_name//[:\/]/_}_attempt_$${attempt}.log"; then
             # Verify model was actually downloaded
             if ollama list | grep -q "$model_name"; then
               echo "✅ Successfully downloaded and verified: $model_name"
@@ -1346,92 +1346,92 @@ runcmd:
           else
             local exit_code=$?
             echo "❌ Download failed with exit code $exit_code: $model_name (attempt $attempt/$max_retries)"
-            
+
             # Log specific error details
             if [ $exit_code -eq 124 ]; then
               echo "🕐 Timeout: Download took longer than 30 minutes"
             elif [ $exit_code -eq 1 ]; then
               echo "🌐 Network error: Check connectivity to Ollama registry"
             fi
-            
+
             # Show last few lines of log for debugging
             echo "📋 Last 5 lines of download log:"
-            tail -5 "/tmp/ollama_${model_name//[:\/]/_}_attempt_${attempt}.log" 2>/dev/null || echo "No log available"
+            tail -5 "/tmp/ollama_$${model_name//[:\/]/_}_attempt_$${attempt}.log" 2>/dev/null || echo "No log available"
           fi
-          
+
           # Wait before retry (except on last attempt)
           if [ $attempt -lt $max_retries ]; then
-            echo "⏸️  Waiting ${retry_delay}s before retry..."
+            echo "⏸️  Waiting $${retry_delay}s before retry..."
             sleep $retry_delay
             retry_delay=$((retry_delay * 2))  # Exponential backoff
           fi
         done
-        
+
         echo "💥 FAILED: Could not download $model_name after $max_retries attempts"
         return 1
       }
-      
+
       # Function to check available disk space before downloads
       check_disk_space() {
         local required_gb=$1
         local available_kb=$(df /root/.ollama | awk 'NR==2 {print $4}')
         local available_gb=$((available_kb / 1024 / 1024))
-        
-        echo "💾 Disk space check: ${available_gb}GB available, ${required_gb}GB required"
-        
+
+        echo "💾 Disk space check: $${available_gb}GB available, $${required_gb}GB required"
+
         if [ $available_gb -lt $required_gb ]; then
-          echo "❌ ERROR: Insufficient disk space. Need ${required_gb}GB, have ${available_gb}GB"
+          echo "❌ ERROR: Insufficient disk space. Need $${required_gb}GB, have $${available_gb}GB"
           return 1
         fi
-        
+
         echo "✅ Sufficient disk space available"
         return 0
       }
-      
+
       # Check if Ollama service is ready
       if wait_for_ollama_ready; then
         # Check disk space (estimate 25GB needed for both models)
         if check_disk_space 25; then
-          
+
           # Define models to download with priorities
           declare -a CRITICAL_MODELS=("deepseek-r1:latest")
           declare -a OPTIONAL_MODELS=("gpt-oss:20b")
-          
+
           # Download critical models first
           echo "🎯 Phase 1: Downloading critical models..."
           CRITICAL_SUCCESS=0
-          CRITICAL_TOTAL=${#CRITICAL_MODELS[@]}
-          
-          for model in "${CRITICAL_MODELS[@]}"; do
+          CRITICAL_TOTAL=$${#CRITICAL_MODELS[@]}
+
+          for model in "$${CRITICAL_MODELS[@]}"; do
             if download_ollama_model "$model"; then
               CRITICAL_SUCCESS=$((CRITICAL_SUCCESS + 1))
             fi
           done
-          
+
           echo "📊 Critical models: $CRITICAL_SUCCESS/$CRITICAL_TOTAL successful"
-          
+
           # Download optional models
           echo "🔧 Phase 2: Downloading optional models..."
           OPTIONAL_SUCCESS=0
-          OPTIONAL_TOTAL=${#OPTIONAL_MODELS[@]}
-          
-          for model in "${OPTIONAL_MODELS[@]}"; do
+          OPTIONAL_TOTAL=$${#OPTIONAL_MODELS[@]}
+
+          for model in "$${OPTIONAL_MODELS[@]}"; do
             if download_ollama_model "$model"; then
               OPTIONAL_SUCCESS=$((OPTIONAL_SUCCESS + 1))
             fi
           done
-          
+
           echo "📊 Optional models: $OPTIONAL_SUCCESS/$OPTIONAL_TOTAL successful"
-          
+
           # Final status report
           TOTAL_SUCCESS=$((CRITICAL_SUCCESS + OPTIONAL_SUCCESS))
           TOTAL_MODELS=$((CRITICAL_TOTAL + OPTIONAL_TOTAL))
-          
+
           echo "🏁 Final Results:"
           echo "   ✅ Successfully downloaded: $TOTAL_SUCCESS/$TOTAL_MODELS models"
           echo "   📁 Models available:"
           ollama list | grep -E "(NAME|deepseek|gpt-oss)" || echo "   No models found"
-          
+
           # Set success indicator for monitoring
           if [ $CRITICAL_SUCCESS -eq $CRITICAL_TOTAL ]; then
             echo "✅ All critical Ollama models downloaded successfully"
@@ -1439,22 +1439,22 @@ runcmd:
           else
             echo "⚠️  Some critical Ollama models failed to download"
           fi
-          
+
           if [ $TOTAL_SUCCESS -eq $TOTAL_MODELS ]; then
             echo "🎉 All Ollama models downloaded successfully!"
             echo "export OLLAMA_ALL_MODELS_READY=true" >> /etc/environment
           fi
-          
+
         else
           echo "❌ Skipping model downloads due to insufficient disk space"
         fi
       else
         echo "❌ Skipping model downloads - Ollama service not ready"
       fi
-      
+
       # Cleanup temporary log files older than 1 hour
       find /tmp -name "ollama_*_attempt_*.log" -mmin +60 -delete 2>/dev/null || true
-      
+
     else
       echo "❌ Ollama installation failed, skipping model downloads"
     fi
@@ -1473,12 +1473,12 @@ runcmd:
   - |
     # Fix for GitHub issue #396: AWS CLI v2 PyInstaller/prompt_toolkit TypeError
     # Multiple installation methods with fallbacks to resolve Python compatibility issues
-    
+
     install_aws_cli() {
         local method="$1"
         local attempt="$2"
         echo "[Attempt $attempt] Installing AWS CLI using method: $method"
-        
+
         case "$method" in
             "apt")
                 # Method 1: APT package manager (AWS CLI v1 - more stable)
@@ -1499,14 +1499,14 @@ runcmd:
             "v2-enhanced")
                 # Method 3: Enhanced v2 installation with environment fixes
                 echo "Installing AWS CLI v2 with PyInstaller compatibility fixes..."
-                
+
                 # Set environment variables to fix prompt_toolkit issues
                 export PYTHONIOENCODING=utf-8
                 export LC_ALL=C.UTF-8
                 export LANG=C.UTF-8
                 export TERM=xterm-256color
                 export PROMPT_TOOLKIT_NO_CPR=1
-                
+
                 # Download and install with error handling
                 if curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip"; then
                     cd /tmp
@@ -1526,7 +1526,7 @@ runcmd:
                 fi
                 ;;
         esac
-        
+
         # Test installation
         if command -v aws >/dev/null 2>&1; then
             # Test basic functionality
@@ -1542,11 +1542,11 @@ runcmd:
             return 1
         fi
     }
-    
+
     # Try installation methods in order of preference (POSIX-compatible)
     SUCCESS=false
     attempt=1
-    
+
     # Method 1: APT package manager
     if [ "$SUCCESS" = "false" ]; then
         if install_aws_cli "apt" "$attempt"; then
@@ -1558,7 +1558,7 @@ runcmd:
             attempt=$((attempt + 1))
         fi
     fi
-    
+
     # Method 2: Python pip
     if [ "$SUCCESS" = "false" ]; then
         if install_aws_cli "pip" "$attempt"; then
@@ -1570,7 +1570,7 @@ runcmd:
             attempt=$((attempt + 1))
         fi
     fi
-    
+
     # Method 3: Enhanced v2 installation
     if [ "$SUCCESS" = "false" ]; then
         if install_aws_cli "v2-enhanced" "$attempt"; then
@@ -1582,7 +1582,7 @@ runcmd:
             attempt=$((attempt + 1))
         fi
     fi
-    
+
     # Method 4: Snap package fallback
     if [ "$SUCCESS" = "false" ]; then
         if install_aws_cli "snap" "$attempt"; then
@@ -1592,7 +1592,7 @@ runcmd:
             rm -rf /tmp/aws* /opt/aws-cli-venv 2>/dev/null || true
         fi
     fi
-    
+
     if [ "$SUCCESS" = "false" ]; then
         echo "ERROR: All AWS CLI installation methods failed" >&2
         echo "ERROR: This may cause issues with AWS-related functionality" >&2
@@ -1602,7 +1602,7 @@ runcmd:
         mkdir -p /root/.aws
         echo "complete -C '/usr/local/bin/aws_completer' aws" >> /root/.bashrc 2>/dev/null || true
         echo "complete -C '/usr/local/bin/aws_completer' aws" >> /root/.zshrc 2>/dev/null || true
-        
+
         # Create default AWS config with better error handling
         cat > /root/.aws/config << 'EOF'
 [default]
@@ -1612,7 +1612,7 @@ cli_pager =
 max_attempts = 3
 retry_mode = adaptive
 EOF
-        
+
         echo "SUCCESS: AWS CLI installation completed successfully"
     fi
   - |
@@ -1906,57 +1906,57 @@ EOF
     # SSH Security Hardening Implementation
     # Configure fail2ban, UFW firewall, and security monitoring
     echo "[$(date)] Implementing SSH security hardening..." >> /var/log/security-events.log
-    
+
     # Create security logs directory
     mkdir -p /var/log/security
     touch /var/log/security-events.log /var/log/security-report.log
     chmod 640 /var/log/security-events.log /var/log/security-report.log
-    
+
     # Configure UFW firewall
     echo "Configuring UFW firewall..."
     ufw --force reset
     ufw default deny incoming
     ufw default allow outgoing
-    
+
     # Allow SSH (port 22) with rate limiting
     ufw limit ssh comment "SSH with rate limiting"
-    
+
     # Allow essential services
     ufw allow out 53 comment "DNS outgoing"
     ufw allow out 80 comment "HTTP outgoing"
     ufw allow out 443 comment "HTTPS outgoing"
     ufw allow out 123 comment "NTP outgoing"
-    
+
     # Allow Docker networks
     ufw allow from 172.16.0.0/12 comment "Docker networks"
     ufw allow from 10.0.0.0/8 comment "Internal networks"
     ufw allow from 192.168.0.0/16 comment "Private networks"
-    
+
     # Enable firewall
     ufw --force enable
     echo "✅ UFW firewall configured and enabled"
-    
+
     # Configure fail2ban
     echo "Configuring fail2ban..."
-    
+
     # Stop fail2ban if running to ensure clean configuration
     systemctl stop fail2ban 2>/dev/null || true
-    
+
     # Update fail2ban configuration ownership
     chown root:root /etc/fail2ban/jail.d/cloudshell-custom.conf
     chown root:root /etc/fail2ban/filter.d/sshd-aggressive.conf
     chown root:root /etc/fail2ban/action.d/cloudshell-notify.conf
-    
+
     # Restart rsyslog to ensure proper logging
     systemctl restart rsyslog
-    
+
     # Start and enable fail2ban
     systemctl enable fail2ban
     systemctl start fail2ban
-    
+
     # Wait for fail2ban to start and configure jails
     sleep 5
-    
+
     # Verify fail2ban jails are active
     for jail in sshd sshd-aggressive recidive; do
         if fail2ban-client status "$jail" >/dev/null 2>&1; then
@@ -1967,24 +1967,24 @@ EOF
             sleep 2
         fi
     done
-    
+
     # Enable and start security monitoring services
     systemctl daemon-reload
     systemctl enable security-monitor.service
     systemctl enable security-report.timer
     systemctl start security-monitor.service
     systemctl start security-report.timer
-    
+
     echo "✅ Security monitoring services started"
-    
+
     # Generate initial security report
     /usr/local/bin/security-monitor.sh geoip
     /usr/local/bin/security-monitor.sh report
-    
+
     # Install additional security tools
     apt-get update -qq
     apt-get install -y geoip-bin geoip-database lynis chkrootkit rkhunter logwatch 2>/dev/null || true
-    
+
     # Configure log rotation for security logs
     cat > /etc/logrotate.d/security-logs << 'EOF'
 /var/log/security-events.log {
@@ -2010,19 +2010,19 @@ EOF
     copytruncate
 }
 EOF
-    
+
     # Set up SSH configuration validation cron job
     echo "0 */6 * * * root /usr/local/bin/ssh-security-check.sh >> /var/log/security-report.log 2>&1" > /etc/cron.d/ssh-security-check
-    
+
     # Final SSH service restart to apply all hardening configurations
     echo "Restarting SSH service to apply security hardening..."
     systemctl restart ssh
-    
+
     # Verify SSH is still accessible
     if systemctl is-active ssh >/dev/null 2>&1; then
         echo "✅ SSH service restarted successfully with hardened configuration"
         echo "[$(date)] SSH security hardening completed successfully" >> /var/log/security-events.log
-        
+
         # Log current security status
         echo "=== Security Hardening Summary ===" >> /var/log/security-events.log
         echo "UFW Status: $(ufw status | head -1)" >> /var/log/security-events.log
@@ -2031,7 +2031,7 @@ EOF
         echo "Password Auth: $(sshd -T | grep passwordauthentication)" >> /var/log/security-events.log
         echo "Security Monitor: $(systemctl is-active security-monitor.service)" >> /var/log/security-events.log
         echo "===============================" >> /var/log/security-events.log
-        
+
         # Run initial security check
         /usr/local/bin/ssh-security-check.sh >> /var/log/security-report.log 2>&1 || true
     else
@@ -2042,14 +2042,14 @@ EOF
   - |
     # Enhanced SSH Attack Analysis and Response
     echo "[$(date)] Starting enhanced SSH attack analysis..." >> /var/log/security-events.log
-    
+
     # Analyze current attacks and pre-populate fail2ban with known attackers
     if [ -f /var/log/auth.log ]; then
         echo "Analyzing recent SSH attacks..."
-        
+
         # Extract attacking IPs from the last 24 hours
         ATTACK_IPS=$(grep "$(date '+%Y-%m-%d')" /var/log/auth.log | grep -E "Failed password|Invalid user" | awk '{print $(NF-3)}' | sort | uniq -c | sort -nr | awk '$1 >= 3 {print $2}' | head -20)
-        
+
         if [ -n "$ATTACK_IPS" ]; then
             echo "Pre-banning persistent attackers:"
             echo "$ATTACK_IPS" | while read -r ip; do
@@ -2063,14 +2063,14 @@ EOF
                 fi
             done
         fi
-        
+
         # Generate immediate threat assessment
         echo "=== Immediate Threat Assessment - $(date) ===" >> /var/log/security-events.log
         echo "Recent attack summary:" >> /var/log/security-events.log
         grep "$(date '+%Y-%m-%d')" /var/log/auth.log | grep -E "Failed password|Invalid user" | awk '{print $(NF-3)}' | sort | uniq -c | sort -nr | head -10 >> /var/log/security-events.log 2>/dev/null || echo "No attacks detected today" >> /var/log/security-events.log
         echo "=========================================" >> /var/log/security-events.log
     fi
-    
+
     # Set up real-time attack alerting
     cat > /usr/local/bin/ssh-attack-alert.sh << 'EOSCRIPT'
 #!/bin/bash
@@ -2087,7 +2087,7 @@ count_recent_failures() {
     local ip="$1"
     local since_time
     since_time=$(date -d "-$${TIME_WINDOW} seconds" '+%Y-%m-%d %H:%M:%S')
-    
+
     grep "$since_time" "$LOG_FILE" 2>/dev/null | grep -E "Failed password|Invalid user" | grep "$ip" | wc -l || echo "0"
 }
 
@@ -2101,7 +2101,7 @@ if [ -f "$LOG_FILE" ]; then
                 if [ "$FAIL_COUNT" -ge "$ALERT_THRESHOLD" ]; then
                     echo "[$(date)] CRITICAL ALERT: Rapid attack from $IP - $FAIL_COUNT failures in $${TIME_WINDOW}s" >> "$ALERT_LOG"
                     logger -p auth.crit "CRITICAL SSH ATTACK: IP $IP has $FAIL_COUNT failures in $${TIME_WINDOW} seconds"
-                    
+
                     # Immediate ban via fail2ban
                     fail2ban-client set sshd banip "$IP" 2>/dev/null || true
                 fi
@@ -2110,9 +2110,9 @@ if [ -f "$LOG_FILE" ]; then
     done &
 fi
 EOSCRIPT
-    
+
     chmod +x /usr/local/bin/ssh-attack-alert.sh
-    
+
     # Start real-time alerting in background
     nohup /usr/local/bin/ssh-attack-alert.sh > /dev/null 2>&1 &
     echo "✅ Real-time SSH attack alerting enabled"


### PR DESCRIPTION
## Summary

This PR fixes the critical Terraform templatefile validation errors that were blocking all infrastructure deployments. The issue was caused by bash parameter substitution syntax being incorrectly interpreted by Terraform's `templatefile()` function as HCL syntax.

## Changes Made

Fixed the following bash variable expressions by escaping them with `$${}` syntax:

- `${model_name//[:\/]/_}` → `$${model_name//[:\/]/_}` (bash parameter substitution for filename sanitization)
- `${#CRITICAL_MODELS[@]}` → `$${#CRITICAL_MODELS[@]}` (bash array length)
- `${#OPTIONAL_MODELS[@]}` → `$${#OPTIONAL_MODELS[@]}` (bash array length)  
- `"${CRITICAL_MODELS[@]}"` → `"$${CRITICAL_MODELS[@]}"` (bash array expansion)
- `"${OPTIONAL_MODELS[@]}"` → `"$${OPTIONAL_MODELS[@]}"` (bash array expansion)
- `${retry_delay}` → `$${retry_delay}` (bash variable for sleep timing)
- `${available_gb}` and `${required_gb}` → `$${available_gb}` and `$${required_gb}` (disk space variables)

## Root Cause

The Terraform `templatefile()` function was attempting to parse bash-specific syntax as HCL variable interpolations, causing validation errors:

```
Call to function "templatefile" failed:
./cloud-init/CLOUDSHELL.conf:1340,28-29: Unsupported operator; Bitwise
operators are not supported. Did you mean boolean OR ("||")?, and 283 other
diagnostic(s).
```

## Testing

- ✅ `terraform fmt` passes
- ✅ `terraform validate` passes  
- ✅ All bash syntax preserved for runtime execution
- ✅ Terraform template variables (prefixed with `var_`) remain unchanged

## Impact

**Critical Fix**: This resolves the complete infrastructure deployment failure affecting all GitHub Actions workflows. Without this fix, no infrastructure changes can be deployed.

## Files Changed

- `cloud-init/CLOUDSHELL.conf` - Fixed bash parameter substitution escaping

Closes #405

## Test Plan

- [x] Terraform validation passes locally
- [ ] GitHub Actions infrastructure workflow passes 
- [ ] Cloud-init template executes correctly on deployed VMs
- [ ] Ollama model downloads work with sanitized filenames