### PR TITLE
Optimize cloud-init apt sources ordering for CLOUDSHELL VM

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -46,12 +46,6 @@ apt:
       source: ppa:dotnet/backports
     ansible:
       source: ppa:ansible/ansible
-%{ if var_has_gpu ~}
-    nvtop:
-      source: ppa:quentiumyt/nvtop
-    nvidia:
-      source: ppa:graphics-drivers/ppa
-%{ endif ~}
     trivy:
       source: deb [arch=amd64 signed-by=$KEY_FILE] https://get.trivy.dev/deb generic main
       keyserver: https://get.trivy.dev/deb/public.key
@@ -76,12 +70,6 @@ apt:
       source: deb [arch=amd64 signed-by=$KEY_FILE] https://download.docker.com/linux/ubuntu noble stable
       keyserver: https://download.docker.com/linux/ubuntu/gpg
       keyid: 8D81803C0EBFCD88
-%{ if var_has_gpu ~}
-    nvidia-container-toolkit:
-      source: deb [arch=amd64 signed-by=$KEY_FILE] https://nvidia.github.io/libnvidia-container/stable/deb/$(ARCH) /
-      keyserver: https://nvidia.github.io/libnvidia-container/gpgkey
-      keyid: DDCAE044F796ECB0
-%{ endif ~}
     azure-cli:
       source: deb [arch=amd64 signed-by=$KEY_FILE] https://packages.microsoft.com/repos/azure-cli/ $RELEASE main
       keyserver: https://packages.microsoft.com/keys/microsoft.asc
@@ -98,6 +86,16 @@ apt:
       source: "deb http://archive.ubuntu.com/ubuntu $RELEASE universe"
     ubuntu-multiverse:
       source: "deb http://archive.ubuntu.com/ubuntu $RELEASE multiverse"
+%{ if var_has_gpu ~}
+    nvidia-container-toolkit:
+      source: deb [arch=amd64 signed-by=$KEY_FILE] https://nvidia.github.io/libnvidia-container/stable/deb/$(ARCH) /
+      keyserver: https://nvidia.github.io/libnvidia-container/gpgkey
+      keyid: DDCAE044F796ECB0
+    nvtop:
+      source: ppa:quentiumyt/nvtop
+    nvidia:
+      source: ppa:graphics-drivers/ppa
+%{ endif ~}
 
 write_files:
   - path: /opt/setup-github-runner.sh


### PR DESCRIPTION
## Summary
- Move GPU-specific apt sources to the end of the sources list to improve package dependency resolution
- Relocate nvidia-container-toolkit, nvtop, and nvidia sources to conditional GPU section
- Maintain all functionality while optimizing source ordering

## Changes
- **Relocated nvidia-container-toolkit source**: Moved after ubuntu repositories for better dependency resolution
- **Moved nvtop and nvidia PPA sources**: Placed in conditional GPU section at end of sources list
- **Improved ordering**: GPU-specific sources now come after core Ubuntu repositories

## Benefits
- Better package dependency resolution during cloud-init execution
- Reduced potential conflicts between GPU and core package sources
- More logical grouping of conditional GPU-related configurations

## Testing
- [x] Template structure validated
- [x] All existing functionality preserved
- [x] GPU conditional logic maintained

🤖 Generated with [Claude Code](https://claude.ai/code)