### PR TITLE
Fix YAML syntax error in bootcmd section with proper indentation

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -16,9 +16,9 @@ power_state:
 bootcmd:
   - mkdir -p /home /var/lib/docker /root/.ollama
   - |
-format_and_mount(){local lun="$1" label="$2" mount_point="$3" always_format="$4";local dev="/dev/disk/azure/scsi1/lun$lun";local part="$dev-part1";for i in $(seq 1 30);do if [ -b "$dev" ];then break;fi;sleep 2;done;if [ "$always_format" = "yes" ];then if mount | grep -q "$part";then umount -f "$part" >/dev/null 2>&1||true;fi;wipefs -a "$dev" >/dev/null 2>&1||true;parted -s "$dev" mklabel gpt mkpart primary ext4 0% 100%;mkfs.ext4 -F "$part" -L "$label";else if ! blkid "$part" >/dev/null 2>&1;then parted -s "$dev" mklabel gpt mkpart primary ext4 0% 100%;mkfs.ext4 -F "$part" -L "$label";fi;fi;}
-
-format_and_mount 0 homefs /home yes;format_and_mount 1 dockerfs /var/lib/docker no;format_and_mount 2 ollamafs /root/.ollama no
+    format_and_mount(){local lun="$1" label="$2" mount_point="$3" always_format="$4";local dev="/dev/disk/azure/scsi1/lun$lun";local part="$dev-part1";for i in $(seq 1 30);do if [ -b "$dev" ];then break;fi;sleep 2;done;if [ "$always_format" = "yes" ];then if mount | grep -q "$part";then umount -f "$part" >/dev/null 2>&1||true;fi;wipefs -a "$dev" >/dev/null 2>&1||true;parted -s "$dev" mklabel gpt mkpart primary ext4 0% 100%;mkfs.ext4 -F "$part" -L "$label";else if ! blkid "$part" >/dev/null 2>&1;then parted -s "$dev" mklabel gpt mkpart primary ext4 0% 100%;mkfs.ext4 -F "$part" -L "$label";fi;fi;}
+    
+    format_and_mount 0 homefs /home yes;format_and_mount 1 dockerfs /var/lib/docker no;format_and_mount 2 ollamafs /root/.ollama no
 
 mounts:
   - ["LABEL=homefs", "/home", "ext4", "defaults,nofail", "0", "2"]


### PR DESCRIPTION
## Problem
Cloud-init is failing with YAML parsing error:
```
[   10.050426] cloud-init[856]: 2025-08-28 01:19:49,832 - util.py[WARNING]: Failed loading yaml blob. Invalid format at line 19 column 1: "while scanning a simple key
[   10.054561] cloud-init[856]:   in "<unicode string>", line 19, column 1:
[   10.056491] cloud-init[856]:     format_and_mount(){local lun="$1 ...
[   10.058399] cloud-init[856]:     ^
[   10.059439] cloud-init[856]: could not find expected ':'
```

## Root Cause
The multiline block in the `bootcmd` section was missing proper YAML indentation:
- Shell function definition was not indented under the `|` block
- Function calls were not indented properly
- YAML parser couldn't parse the block structure correctly

## Solution
- **Fixed indentation**: Added proper 4-space indentation to shell function definition
- **Fixed function calls**: Properly indented the format_and_mount function calls  
- **Maintained functionality**: No changes to shell logic, only YAML structure

## Impact
- ✅ Cloud-init will properly parse the YAML configuration
- ✅ Eliminates "Failed loading yaml blob" errors
- ✅ Ensures bootcmd section executes correctly during VM initialization
- ✅ No functional changes to disk formatting logic

## Testing
- [x] YAML syntax validated with proper indentation
- [x] Shell function logic preserved
- [x] Template structure maintained

🤖 Generated with [Claude Code](https://claude.ai/code)