### PR TITLE
Fix YAML indentation error in prewarm-cache.sh write_files section

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -601,11 +601,11 @@ write_files:
     permissions: '0755'
     owner: root:root
     content: |
-        for i in {1..30}
-        do
-            command -v code >/dev/null 2>&1 && break
-            sleep 2
-        done
+      for i in {1..30}
+      do
+          command -v code >/dev/null 2>&1 && break
+          sleep 2
+      done
       if command -v code >/dev/null 2>&1; then
         echo "Installing VS Code extensions..."
         timeout 300 bash -c '


### PR DESCRIPTION
## Problem
Cloud-init failing with YAML parsing error:
```
[   11.115525] cloud-init[851]: 2025-08-28 01:28:39,077 - util.py[WARNING]: Failed loading yaml blob. Invalid format at line 654 column 5: "while parsing a block mapping
[   11.122502] cloud-init[851]:       - path: /root/prewarm-cache.sh
[   11.125881] cloud-init[851]: expected <block end>, but found '<scalar>'
[   11.130549] cloud-init[851]:           if command -v code >/dev/null 2> ...
```

## Root Cause
Inconsistent indentation in the `/root/prewarm-cache.sh` file content block:
- **Line 604**: `for` loop had 8-space indentation (2 extra spaces)  
- **Line 609**: `if` statement had 6-space indentation
- YAML parser expected consistent indentation throughout the multiline content block

## Solution
- **Standardized indentation**: Fixed all content to use consistent 6-space indentation
- **Fixed for loop**: Reduced indentation from 8 spaces to 6 spaces
- **Maintained functionality**: No changes to script logic, only YAML structure
- **Consistent formatting**: All script content now properly aligned

## Impact
- ✅ Cloud-init will properly parse the write_files section
- ✅ Eliminates "Failed loading yaml blob" errors  
- ✅ Ensures prewarm-cache.sh script is written correctly during VM setup
- ✅ No functional changes to VS Code extension installation logic

## Testing
- [x] YAML indentation validated and consistent
- [x] Script functionality preserved
- [x] Template structure maintained

🤖 Generated with [Claude Code](https://claude.ai/code)