### PR TITLE
Fix YAML indentation error in logrotate configuration heredoc

### DIFF
--- a/cloud-init/CLOUDSHELL.conf
+++ b/cloud-init/CLOUDSHELL.conf
@@ -1121,29 +1121,29 @@ runcmd:
     echo "[$(date)] Implementing SSH security hardening..." >> /var/log/security-events.log;mkdir -p /var/log/security;touch /var/log/security-events.log /var/log/security-report.log;chmod 640 /var/log/security-events.log /var/log/security-report.log;ufw --force reset;ufw default deny incoming;ufw default allow outgoing;ufw limit ssh comment "SSH with rate limiting";ufw allow out 53 comment "DNS outgoing";ufw allow out 80 comment "HTTP outgoing";ufw allow out 443 comment "HTTPS outgoing";ufw allow out 123 comment "NTP outgoing";ufw allow from 172.16.0.0/12 comment "Docker networks";ufw allow from 10.0.0.0/8 comment "Internal networks";ufw allow from 192.168.0.0/16 comment "Private networks";ufw --force enable;systemctl stop fail2ban 2>/dev/null || true;chown root:root /etc/fail2ban/jail.d/cloudshell-custom.conf /etc/fail2ban/filter.d/sshd-aggressive.conf /etc/fail2ban/action.d/cloudshell-notify.conf;systemctl restart rsyslog;systemctl enable fail2ban;systemctl start fail2ban;sleep 5;for jail in sshd sshd-aggressive recidive;do fail2ban-client status "$jail" >/dev/null 2>&1||{ fail2ban-client reload 2>/dev/null;sleep 2;};done;systemctl daemon-reload;systemctl enable security-monitor.service security-report.timer;systemctl start security-monitor.service security-report.timer;/usr/local/bin/security-monitor.sh geoip;/usr/local/bin/security-monitor.sh report;apt-get update -qq;apt-get install -y geoip-bin geoip-database lynis chkrootkit rkhunter logwatch 2>/dev/null || true
 
     cat > /etc/logrotate.d/security-logs << 'EOF'
-/var/log/security-events.log {
-    daily
-    missingok
-    rotate 30
-    compress
-    delaycompress
-    notifempty
-    copytruncate
-    postrotate
-        logger -p auth.info "Security log rotated"
-    endscript
-}
-
-/var/log/security-report.log {
-    weekly
-    missingok
-    rotate 12
-    compress
-    delaycompress
-    notifempty
-    copytruncate
-}
-EOF
+    /var/log/security-events.log {
+        daily
+        missingok
+        rotate 30
+        compress
+        delaycompress
+        notifempty
+        copytruncate
+        postrotate
+            logger -p auth.info "Security log rotated"
+        endscript
+    }
+    
+    /var/log/security-report.log {
+        weekly
+        missingok
+        rotate 12
+        compress
+        delaycompress
+        notifempty
+        copytruncate
+    }
+    EOF
 
     echo "0 */6 * * * root /usr/local/bin/ssh-security-check.sh >> /var/log/security-report.log 2>&1" > /etc/cron.d/ssh-security-check
 


### PR DESCRIPTION
## Problem
Cloud-init failing with YAML parsing error in logrotate configuration:
```
[   10.043866] cloud-init[853]: 2025-08-28 16:29:35,997 - util.py[WARNING]: Failed loading yaml blob. Invalid format at line 1084 column 1: "while scanning a simple key
[   10.050238] cloud-init[853]:     /var/log/security-events.log {
[   10.053201] cloud-init[853]: could not find expected ':'
```

## Root Cause
Logrotate configuration heredoc content was not properly indented within the YAML multiline block:
- **Line 1124**: `/var/log/security-events.log {` had no indentation (column 1)
- **Lines 1124-1146**: Entire logrotate configuration was unindented
- YAML parser expected consistent indentation within the multiline script block

## Solution
- **Fixed indentation**: Added proper 4-space indentation to entire heredoc content
- **Consistent formatting**: All logrotate directives now properly aligned
- **Maintained functionality**: All security log rotation rules preserved
- **Preserved heredoc syntax**: EOF markers and content structure intact

## Changes Summary
- ✅ Indented `/var/log/security-events.log` and `/var/log/security-report.log` blocks
- ✅ Indented all logrotate configuration directives
- ✅ Maintained proper heredoc structure with `cat > /etc/logrotate.d/security-logs`
- ✅ Preserved SSH security hardening script functionality

## Impact
- ✅ Cloud-init will properly parse the SSH security hardening script
- ✅ Eliminates "could not find expected ':'" YAML errors
- ✅ Ensures security log rotation is configured correctly during VM setup
- ✅ No functional changes to SSH hardening or log management

## Testing
- [x] YAML indentation validated and consistent
- [x] Logrotate configuration syntax preserved
- [x] SSH security script functionality maintained

🤖 Generated with [Claude Code](https://claude.ai/code)